### PR TITLE
fix localization warnings on gas analyzer (Bugfix)

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
@@ -265,7 +265,7 @@ public sealed class GasAnalyzerSystem : EntitySystem
 
             if (mixture != null)
             {
-                var gasName = Loc.GetString(gas.Name);
+                var gasName = gas.Name;
                 gases.Add(new GasEntry(gasName, mixture[i], gas.Color));
             }
         }


### PR DESCRIPTION
## About the PR
Using a gas analyzer would spam the client console with warnings. This PR fixes that. 

## Why / Balance
Bugfix

## Technical details
Gas names have proper localization but it looks like the analyzer was never updated. 

## Media
None

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.

## License
MIT

## Breaking changes
None

**Changelog**
:cl:
- fix: Opening the gas analyzer no longer spams the client console with warnings
