### PR TITLE
Vault Item Tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -166,16 +166,25 @@
         Blunt: 20
 
 - type: entity
-  name: golden toolbox
-  parent: ToolboxBase
+  name: golden toolbox # Funky Station, changed to have the statline of the suspicous toolbox
+  parent: [ToolboxBase, BaseCommandContraband]
   id: ToolboxGolden
-  description: A solid gold toolbox. A rapper would kill for this.
+  description: A solid gold toolbox. A tider would kill for this.
   components:
   - type: Sprite
     sprite: Objects/Tools/Toolboxes/toolbox_gold.rsi
     state: icon
   - type: Item
     sprite: Objects/Tools/Toolboxes/toolbox_gold.rsi
+  - type: Storage
+    maxItemSize: Huge
+    grid:
+    - 0,0,7,3
+  - type: MeleeWeapon
+    autoAttack: true # And also this because funny
+    damage:
+      types:
+        Blunt: 20
 
 - type: entity
   name: foolbox

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -92,7 +92,7 @@
   name: Deckard
   parent: [BaseWeaponRevolver, BaseSecurityCommandContraband]
   id: WeaponRevolverDeckard
-  description: A beautifully machined, custom-built revolver. Used when there is no time for the Voight-Kampff test. Loads 5 rounds of .45 magnum.
+  description: A beautifully machined, custom-built revolver. Used when there is no time for the Voight-Kampff test. Loads 5 rounds of .50 shotgun shells.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/deckard.rsi
@@ -108,6 +108,10 @@
     capacity: 5
     chambers: [ True, True, True, True, True ]
     ammoSlots: [ null, null, null, null, null ]
+    proto: ShellShotgun # Funky Station, Deckard is shotgun revolver.
+    whitelist:
+      tags:
+      - ShellShotgun
   - type: MagazineVisuals
     magState: mag
     steps: 4


### PR DESCRIPTION
## About the PR
A combo port of both [#1420](https://github.com/funky-station/funky-station/pull/1420) and [#1211](https://github.com/funky-station/funky-station/pull/1211)

Bundled together just because both are vault exclusive items
## Why / Balance 
See relevant PRs

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.

## License
MIT

:cl: ThatOneMoon
- tweak: The Deckard has been rechambered to from .45 magnum into .50 shotgun shells
- tweak:  Rebalanced the golden toolbox that exists in the vault, now shares the same stats as a syndicate suspicious toolbox while also being capable of autoswing, now clasified as command contraband.
