### PR TITLE
Contraband Level Changes

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -258,10 +258,10 @@
     sprite: Clothing/Belt/salvagewebbing.rsi
 
 - type: entity
-  parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseSyndicateContraband]
+  parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseMinorContraband]
   id: ClothingBeltMilitaryWebbing
   name: chest rig
-  description: A set of tactical webbing worn by Syndicate boarding parties.
+  description: A set of tactical webbing often worn by boarding parties.
   components:
   - type: Sprite
     sprite: Clothing/Belt/militarywebbing.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -203,7 +203,7 @@
 
 - type: entity
   id: CigPackSyndicate
-  parent: [CigPackBase, BaseSyndicateContraband]
+  parent: [CigPackBase, BaseMinorContraband]
   name: Interdyne herbals packet
   description: Elite cigarettes for elite syndicate agents. Infused with medicine for when you need to do more than calm your nerves.
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -687,7 +687,7 @@
     price: 583 # 3500 for 6 as a freaky fraction
 
 - type: entity
-  parent: [ChemicalMedipen, BaseSyndicateContraband]
+  parent: ChemicalMedipen
   id: CombatMedipen
   name: combat medipen
   description: A single-dose, non-refillable medipen containing a chemical cocktail that treats most forms of damage.

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -140,7 +140,7 @@
 #Empty black
 - type: entity
   id: JetpackBlack
-  parent: [BaseJetpack, BaseSyndicateContraband]
+  parent: BaseJetpack
   name: jetpack
   suffix: Empty
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
@@ -39,7 +39,7 @@
 
 - type: entity
   name: cane blade
-  parent: [BaseSword, BaseSyndicateContraband]
+  parent: [BaseSword, BaseMajorContraband]
   id: CaneBlade
   description: A sharp blade with a cane shaped hilt.
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
See the original PR [#2112](https://github.com/funky-station/funky-station/pull/2112) for the changes.
The only differences are the items not present in Forky, the items that didn't require change and the chest rig being minor contraband instead of major.

## Why / Balance
See original PR.

## Technical details
5 lines changed in a couple of YMLs

## Media
See original PR.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## License
MIT

**Changelog**
:cl:SigmaDraconis
- tweak: Made the chest rig minor contraband
- tweak: Made the interdyne herbals packet minor contraband
- tweak: Made the black jetpack not contraband
- tweak: Made the combat medipen not contraband
- tweak: Made the cane blade major contraband