### PR TITLE
New Trait: Smoker

### DIFF
--- a/Content.Server/Traits/Assorted/SmokerSystem.cs
+++ b/Content.Server/Traits/Assorted/SmokerSystem.cs
@@ -1,0 +1,156 @@
+﻿using Content.Shared.Chemistry.Components;
+using Content.Server.Chat.Systems;
+using Content.Shared.Bed.Sleep;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Popups;
+using Content.Shared.Speech;
+using Content.Shared.Speech.Muting;
+using Content.Shared.Traits.Assorted;
+
+using Robust.Shared.Containers;
+
+namespace Content.Server.Traits.Assorted;
+
+public sealed class SmokerSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ChatSystem _chatSystem = default!;
+    [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
+    private const float UpdateInterval = 1f;
+    private float _updateTimer;
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<SmokerComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(EntityUid uid, SmokerComponent smoker, ComponentStartup args)
+    {
+        smoker.TimeSinceSmoking = 0f;
+        smoker.WithdrawalStage = 0;
+        smoker.CurrentNicotineLevel = 0f;
+        smoker.NextWithdrawalTime = smoker.WithdrawalInterval;
+        EnsureComp<ContainerManagerComponent>(uid);
+        if (!TryComp<ContainerManagerComponent>(uid, out var containerManager))
+        {
+            return;
+        }
+        foreach (var containers in containerManager!.Containers)
+        {
+            if (containers.Key != "solution@bloodstream")
+                continue;
+            foreach (var i in containers.Value.ContainedEntities)
+            {
+                smoker.ChemicalsContainer = i;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Updates the SmokerSystem.
+    /// </summary>
+    /// <param name="frameTime"></param>
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        _updateTimer += frameTime;
+        while (_updateTimer >= UpdateInterval)
+        {
+            _updateTimer -= UpdateInterval;
+
+            var smokerQuery = EntityQueryEnumerator<SmokerComponent>();
+            while (smokerQuery.MoveNext(out var uid, out var smoker))
+            {
+                if (_mobStateSystem.IsIncapacitated(uid) || TryComp<SleepingComponent>(uid, out _))
+                    continue;
+                smoker.TimeSinceSmoking += UpdateInterval;
+                if (CheckNicotineLevel(smoker.ChemicalsContainer, smoker))
+                    continue;
+                SetWithdrawalStage(uid, smoker);
+            }
+        }
+    }
+    /// <summary>
+    /// Checks the current nicotine levels inside solution@chemicals. If the levels are rising (user is smoking)
+    /// resets the WithdrawalStage and TimeSinceSmoking and return True.
+    /// </summary>
+    /// <param name="uid">User's UId.</param>
+    /// <param name="solutionUid">Uid of the Chemicals solution.</param>
+    /// <param name="smoker">User's SmokerComponent.</param>
+    /// <returns></returns>
+    private bool CheckNicotineLevel(EntityUid solutionUid, SmokerComponent smoker)
+    {
+        var currentNicotine = smoker.CurrentNicotineLevel;
+        if (!TryComp<SolutionComponent>(solutionUid, out var solution))
+            return false;
+        foreach (var name in solution.Solution.Contents)
+        {
+            if (name.Reagent.Prototype != smoker.NicotinePrototypeId)
+                continue;
+            if (name.Quantity <= currentNicotine || name.Quantity - currentNicotine == 0.45
+                                                 || name.Quantity - currentNicotine == 0.40)
+            {
+                smoker.CurrentNicotineLevel = name.Quantity;
+                return false;
+            }
+            smoker.CurrentNicotineLevel = name.Quantity;
+            smoker.TimeSinceSmoking = 0;
+            smoker.NextWithdrawalTime = smoker.WithdrawalInterval;
+            smoker.WithdrawalStage = 0;
+            return true;
+        }
+        return false;
+    }
+    /// <summary>
+    /// Check's if the user TimeSinceSmoking is above the threshold and if applicable updates the WithdrawalStage and
+    /// gives an updated time.
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <param name="smoker"></param>
+    private void SetWithdrawalStage(EntityUid uid, SmokerComponent smoker)
+    {
+        // No dividing by zero.
+        if(smoker.WithdrawalStage < 0)
+            smoker.WithdrawalStage = 0;
+        // If it's not the time, continue.
+        if (!(smoker.TimeSinceSmoking >= smoker.NextWithdrawalTime))
+            return;
+        smoker.WithdrawalStage++;
+        // Ensures that ignoring the need to smoke will get harder longer they go.
+        smoker.NextWithdrawalTime += smoker.WithdrawalInterval/(1+Math.Clamp(smoker.WithdrawalStage,0,7));
+        switch (smoker.WithdrawalStage)
+        {
+            case 0:
+                _popup.PopupEntity("All's fine in the world!", uid, uid);
+                break;
+            case 1:
+                _popup.PopupEntity(Loc.GetString("trait-smoker-stage1"),uid,uid);
+                break;
+            case 2:
+                _popup.PopupEntity(Loc.GetString("trait-smoker-stage2"), uid, uid,PopupType.Medium);
+                break;
+            case 3:
+                _popup.PopupEntity(Loc.GetString("trait-smoker-stage3"), uid, uid,PopupType.MediumCaution);
+                if (TryComp<SpeechComponent>(uid,out _) && !TryComp<MutedComponent>(uid, out _))
+                    _chatSystem.TryEmoteWithChat(uid,"Sigh");
+                break;
+            case 4:
+                _popup.PopupEntity(Loc.GetString("trait-smoker-stage4"), uid, uid,PopupType.MediumCaution);
+                break;
+            case 5:
+                _popup.PopupEntity(Loc.GetString("trait-smoker-stage5"), uid, uid, PopupType.MediumCaution);
+                break;
+            default:
+                _popup.PopupEntity(Loc.GetString("trait-smoker-stage6"), uid, uid, PopupType.MediumCaution);
+                if (TryComp<SpeechComponent>(uid, out _)&& !TryComp<MutedComponent>(uid, out _)&& smoker.WithdrawalStage % 3 == 0)
+                    _chatSystem.TryEmoteWithChat(uid,"Scream");
+                break;
+        }
+    }
+}
+
+
+
+
+
+
+

--- a/Content.Shared/Traits/Assorted/SmokerComponent.cs
+++ b/Content.Shared/Traits/Assorted/SmokerComponent.cs
@@ -1,0 +1,54 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Traits.Assorted;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SmokerComponent : Component
+{
+    /// <summary>
+    /// Time between triggering withdrawal stages when not smoking.
+    /// </summary>
+    [DataField("WithdrawalInterval",required: true)]
+    public float WithdrawalInterval =185f;
+
+    /// <summary>
+    /// Prototype Id of nicotine (or any chemical for that matter).
+    /// </summary>
+    [DataField]
+    public string NicotinePrototypeId = "Nicotine";
+
+    /// <summary>
+    /// Timer added to the total timer after triggering a WithdrawalStage increase.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public float NextWithdrawalTime =0f;
+
+    /// <summary>
+    /// The current stage of withdrawal of the user. It will determine the effects of the withdrawal and the frequency
+    /// of the effects.
+    /// </summary>
+    [DataField]
+    public int WithdrawalStage;
+
+    /// <summary>
+    /// Current nicotine levels inside the user.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly), DataField]
+    public FixedPoint2 CurrentNicotineLevel;
+
+    /// <summary>
+    /// Current time (in seconds) since the user has consumed nicotine.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly), DataField]
+    public float TimeSinceSmoking;
+
+    /// <summary>
+    /// EntityUid of the 'Chemicals' solution of the user.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public EntityUid ChemicalsContainer;
+}
+
+
+

--- a/Resources/Locale/en-US/_Funkystation/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Funkystation/traits/traits.ftl
@@ -1,0 +1,8 @@
+trait-smoker-name = Smoker
+trait-smoker-desc = You are addicted to nicotine.
+trait-smoker-stage1 = A cigarette would be nice..
+trait-smoker-stage2 = You could use a smoke break.
+trait-smoker-stage3 = You must get some nicotine!
+trait-smoker-stage4 = Your feel very agitated!
+trait-smoker-stage5 = You REALLY need to smoke!
+trait-smoker-stage6 = YOUR WHOLE BODY CRAVES NICOTINE!

--- a/Resources/Prototypes/_Funkystation/Traits/quirks.yml
+++ b/Resources/Prototypes/_Funkystation/Traits/quirks.yml
@@ -1,0 +1,9 @@
+- type: trait
+  id: Smoker
+  name: trait-smoker-name
+  description: trait-smoker-desc
+  category: Quirks
+  cost: 0
+  components:
+  - type: Smoker
+    WithdrawalInterval: 185


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
## License
MIT
## About the PR
Added a new trait called "Smoker". This trait gives the user a physical need to consume nicotine at regular intervals or suffer various ailments (mostly psychological). 
This PR will stay as a draft until the required systems for nicotine are ported over.
Port of [https://github.com/funky-station/funky-station/pull/3046](url)

## Why / Balance
Smoking is a way to give flavor to your character. There are multiple vendors providing different forms of tobacco and there are dedicated smoking rooms to smoke in. 
Smoking itself gives no in-game benefits and can sometimes even be dangerous. While it is mostly there for pure roleplay reasons, I want to give the player an in-game incentive to smoke.
I feel the pressure provided by the physical withdrawal effects could lead to tension and interesting roleplay scenarios. 
For example:

- An engineer in atmos choosing to smoke in the bay knowing one leak could end it all
- A secoff on a patrol lighting a cigarette and getting caught by the NTR/HoS
- A scientist smoking while working on an artifact carelessly lights a puddle of flammable liquid (I want more firefighting work for engi)
- The medbay team gathering around for a smoke break after handling a mass casualty event
- An assistant hiding from zombies tries to sneakily light a cigarette, hoping the zeds won't spot them.
- Captain choosing to ban smoking station-wide, causing tension withing the crew.

Obviously, there are many more cases where smoking and the need to smoke could create interesting scenarios.  I think it plays into the Seriously Silly ™ concept Funky is striving for. Seeing a group of highly skilled workers fighting over the last carton of Nomads is funny.

## Technical details
Created a new component called SmokerComponent and the system for it called SmokerSystem. The system finds and saves the 'Chemicals' solution containing the user's reagents. It periodically checks the solution for increases in nicotine levels and if it succeeds, it resets the TimeSinceSmoked. If no nicotine is consumed with a certain time frame, it advances the WithdrawalStage and shows the player a popup encouraging it to smoke. The popups (located in traits.ftl) will get more frequent and persuasive bigger the WithdrawalStage becomes.At the third withdrawal stage it will also makes the player sigh and at max withdrawal stage it will force the player to scream every three increases in the WithdrawalStage (about every minute or so.)

## Media
https://i.imgur.com/5yXwV6R.mp4
(Note that the intervals where the popups and effects happen have been greatly reduced for demonstration purposes. By default they happen between 185 seconds and 22 seconds depending on the stage of withdrawal.)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added trait Smoker. Gives the user the need to consume nicotine regularly.