### PR TITLE
Add playtime towels back into the game

### DIFF
--- a/Resources/Locale/en-US/forensics/fibers.ftl
+++ b/Resources/Locale/en-US/forensics/fibers.ftl
@@ -28,3 +28,7 @@ fibers-regal-blue = regal blue
 fibers-olive = olive
 fibers-silver = silver
 fibers-gold = gold
+# funky start
+fibers-maroon = maroon
+fibers-pink = pink
+# funky end

--- a/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
@@ -77,6 +77,605 @@
   - type: Fiber
     fiberColor: fibers-white
 
+# funky start
+
+- type: entity
+  id: TowelColorPurple
+  name: purple towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#9C0DE1"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#9C0DE1"
+      right:
+      - state: inhand-right
+        color: "#9C0DE1"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#9C0DE1"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#9C0DE1"
+      belt:
+      - state: equipped-BELT
+        color: "#9C0DE1"
+  - type: Fiber
+    fiberColor: fibers-purple
+
+- type: entity
+  id: TowelColorRed
+  name: red towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#940000"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#940000"
+      right:
+      - state: inhand-right
+        color: "#940000"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#940000"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#940000"
+      belt:
+      - state: equipped-BELT
+        color: "#940000"
+  - type: Fiber
+    fiberColor: fibers-red
+
+- type: entity
+  id: TowelColorBlue
+  name: blue towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#0089EF"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#0089EF"
+      right:
+      - state: inhand-right
+        color: "#0089EF"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#0089EF"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#0089EF"
+      belt:
+      - state: equipped-BELT
+        color: "#0089EF"
+  - type: Fiber
+    fiberColor: fibers-blue
+
+- type: entity
+  id: TowelColorDarkBlue
+  name: dark blue towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#3285ba"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#3285ba"
+      right:
+      - state: inhand-right
+        color: "#3285ba"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#3285ba"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#3285ba"
+      belt:
+      - state: equipped-BELT
+        color: "#3285ba"
+  - type: Fiber
+    fiberColor: fibers-blue
+
+- type: entity
+  id: TowelColorLightBlue
+  name: light blue towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#58abcc"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#58abcc"
+      right:
+      - state: inhand-right
+        color: "#58abcc"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#58abcc"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#58abcc"
+      belt:
+      - state: equipped-BELT
+        color: "#58abcc"
+  - type: Fiber
+    fiberColor: fibers-blue
+
+- type: entity
+  id: TowelColorTeal
+  name: teal towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#3CB57C"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#3CB57C"
+      right:
+      - state: inhand-right
+        color: "#3CB57C"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#3CB57C"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#3CB57C"
+      belt:
+      - state: equipped-BELT
+        color: "#3CB57C"
+  - type: Fiber
+    fiberColor: fibers-teal
+
+- type: entity
+  id: TowelColorBrown
+  name: brown towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#723A02"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#723A02"
+      right:
+      - state: inhand-right
+        color: "#723A02"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#723A02"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#723A02"
+      belt:
+      - state: equipped-BELT
+        color: "#723A02"
+  - type: Fiber
+    fiberColor: fibers-light-brown
+
+- type: entity
+  id: TowelColorLightBrown
+  name: light brown towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#c59431"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#c59431"
+      right:
+      - state: inhand-right
+        color: "#c59431"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#c59431"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#c59431"
+      belt:
+      - state: equipped-BELT
+        color: "#c59431"
+  - type: Fiber
+    fiberColor: fibers-brown
+
+- type: entity
+  id: TowelColorGray
+  name: gray towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#999999"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#999999"
+      right:
+      - state: inhand-right
+        color: "#999999"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#999999"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#999999"
+      belt:
+      - state: equipped-BELT
+        color: "#999999"
+  - type: Fiber
+    fiberColor: fibers-grey
+
+- type: entity
+  id: TowelColorGreen
+  name: green towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#5ABF2F"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#5ABF2F"
+      right:
+      - state: inhand-right
+        color: "#5ABF2F"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#5ABF2F"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#5ABF2F"
+      belt:
+      - state: equipped-BELT
+        color: "#5ABF2F"
+  - type: Fiber
+    fiberColor: fibers-green
+
+- type: entity
+  id: TowelColorDarkGreen
+  name: dark green towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#639137"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#639137"
+      right:
+      - state: inhand-right
+        color: "#639137"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#639137"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#639137"
+      belt:
+      - state: equipped-BELT
+        color: "#639137"
+  - type: Fiber
+    fiberColor: fibers-green
+
+- type: entity
+  id: TowelColorGold
+  name: gold towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#F7C430"
+    - state: iconstripe
+      color: "#535353"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#F7C430"
+      right:
+      - state: inhand-right
+        color: "#F7C430"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#F7C430"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#F7C430"
+      belt:
+      - state: equipped-BELT
+        color: "#F7C430"
+  - type: Fiber
+    fiberColor: fibers-gold
+
+- type: entity
+  id: TowelColorOrange
+  name: orange towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#EF8100"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#EF8100"
+      right:
+      - state: inhand-right
+        color: "#EF8100"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#EF8100"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#EF8100"
+      belt:
+      - state: equipped-BELT
+        color: "#EF8100"
+  - type: Fiber
+    fiberColor: fibers-orange
+
+- type: entity
+  id: TowelColorBlack
+  name: black towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#535353"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#535353"
+      right:
+      - state: inhand-right
+        color: "#535353"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#535353"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#535353"
+      belt:
+      - state: equipped-BELT
+        color: "#535353"
+  - type: Fiber
+    fiberColor: fibers-black
+
+- type: entity
+  id: TowelColorPink
+  name: pink towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#ffa69b"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#ffa69b"
+      right:
+      - state: inhand-right
+        color: "#ffa69b"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#ffa69b"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#ffa69b"
+      belt:
+      - state: equipped-BELT
+        color: "#ffa69b"
+  - type: Fiber
+    fiberColor: fibers-pink
+
+- type: entity
+  id: TowelColorYellow
+  name: yellow towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#ffe14d"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#ffe14d"
+      right:
+      - state: inhand-right
+        color: "#ffe14d"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#ffe14d"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#ffe14d"
+      belt:
+      - state: equipped-BELT
+        color: "#ffe14d"
+  - type: Fiber
+    fiberColor: fibers-yellow
+
+- type: entity
+  id: TowelColorMaroon
+  name: maroon towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#cc295f"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#cc295f"
+      right:
+      - state: inhand-right
+        color: "#cc295f"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#cc295f"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#cc295f"
+      belt:
+      - state: equipped-BELT
+        color: "#cc295f"
+  - type: Fiber
+    fiberColor: fibers-maroon
+
+- type: entity
+  id: TowelColorSilver
+  name: silver towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#d0d0d0"
+    - state: iconstripe
+      color: "#F7C430"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#d0d0d0"
+      right:
+      - state: inhand-right
+        color: "#d0d0d0"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#d0d0d0"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#d0d0d0"
+      belt:
+      - state: equipped-BELT
+        color: "#d0d0d0"
+  - type: Fiber
+    fiberColor: fibers-silver
+
+- type: entity
+  id: TowelColorMime
+  name: silent towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#EAE8E8"
+    - state: iconstripe
+      color: "#535353"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#EAE8E8"
+      right:
+      - state: inhand-right
+        color: "#EAE8E8"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#EAE8E8"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#EAE8E8"
+      belt:
+      - state: equipped-BELT
+        color: "#EAE8E8"
+  - type: Fiber
+    fiberColor: fibers-white
+
+# funky end
+
 - type: entity
   id: TowelColorNT
   name: NanoTrasen brand towel

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -96,6 +96,21 @@
   - OffsetCaneNT
   - Cane
   - TowelColorWhite
+  - TowelColorGray
+  - TowelColorGreen
+  - TowelColorBlack
+  - TowelColorDarkGreen
+  - TowelColorYellow
+  - TowelColorMaroon
+  - TowelColorLightBlue
+  - TowelColorLightBrown
+  - TowelColorOrange
+  - TowelColorPurple
+  - TowelColorRed
+  - TowelColorDarkBlue
+  - TowelColorCentcom
+  - TowelColorSilver
+  - TowelColorGold
 
 - type: loadoutGroup
   id: Glasses

--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -353,3 +353,213 @@
     back:
     - TowelColorWhite
   groupBy: "towels"
+
+# funky start
+
+- type: loadout
+  id: TowelColorGray
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobPassenger
+      time: 360000 # 100hr
+  storage:
+    back:
+    - TowelColorGray
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorBlack
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobChaplain
+      time: 360000 # 100hr
+  storage:
+    back:
+    - TowelColorBlack
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorRed
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Security
+      time: 360000 # 100hr
+  storage:
+    back:
+    - TowelColorRed
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorOrange
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Engineering
+      time: 360000 # 100hr
+  storage:
+    back:
+    - TowelColorOrange
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorLightBrown
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Cargo
+      time: 360000 # 100hr
+  storage:
+    back:
+    - TowelColorLightBrown
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorYellow
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobClown
+      time: 360000 # 100hr
+  storage:
+    back:
+    - TowelColorYellow
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorDarkGreen
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobLibrarian
+      time: 360000 # 100hr
+  storage:
+    back:
+    - TowelColorDarkGreen
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorGreen
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 360000 # 100hr
+  storage:
+    back:
+    - TowelColorGreen
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorLightBlue
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Medical
+      time: 360000 # 100hr
+  storage:
+    back:
+    - TowelColorLightBlue
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorDarkBlue
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Command
+      time: 360000 # 100hr
+  storage:
+    back:
+    - TowelColorDarkBlue
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorPurple
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Science
+      time: 360000 # 100hr
+  storage:
+    back:
+    - TowelColorPurple
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorMaroon
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobLawyer
+      time: 360000 # 100hr
+  storage:
+    back:
+    - TowelColorMaroon
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorMime
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobMime
+      time: 360000 # 100hr
+  storage:
+    back:
+    - TowelColorMime
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorCentcom
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: CentralCommand
+      time: 360000 # 100hr
+  storage:
+    back:
+    - TowelColorCentcom
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorSilver
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 1800000 # 500hr
+  storage:
+    back:
+    - TowelColorSilver
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorGold
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 3600000 # 1000hr
+  storage:
+    back:
+    - TowelColorGold
+  groupBy: "towels"
+
+  # funky end

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -839,24 +839,3 @@ RightHandSkeleton: OrganSkeletonPersonHandRight
 RightLegHuman: OrganHumanLegRight
 TorsoSkeleton: OrganSkeletonPersonTorso
 RightArmSkeleton: OrganSkeletonPersonArmRight
-
-# 2026-01-19
-TowelColorPurple: null
-TowelColorRed: null
-TowelColorBlue: null
-TowelColorDarkBlue: null
-TowelColorLightBlue: null
-TowelColorTeal: null
-TowelColorBrown: null
-TowelColorLightBrown: null
-TowelColorGray: null
-TowelColorGreen: null
-TowelColorDarkGreen: null
-TowelColorGold: null
-TowelColorOrange: null
-TowelColorBlack: null
-TowelColorPink: null
-TowelColorYellow: null
-TowelColorMaroon: null
-TowelColorSilver: null
-TowelColorMime: null


### PR DESCRIPTION
## About the PR
Reverts https://github.com/space-wizards/space-station-14/pull/42536 and https://github.com/space-wizards/space-station-14/pull/42555
Adds back in https://github.com/funky-station/funky-station/pull/473

In short, put loadout playtime towels back into the game - including the centcom towel.

## Why / Balance
I disagree with the reasoning in wizden's original PR to remove the towels and want to see them back in the game for Forky.

## Technical details

## Media
<img width="1408" height="1297" alt="image" src="https://github.com/user-attachments/assets/9719deb1-3eb1-45e9-b804-2c70823f7302" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.

## License
MIT

## Breaking changes

**Changelog**

No changelog, this does not constitute a change from current Funky