### PR TITLE
Singularity Buster

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -237,6 +237,10 @@
     - id: MetalFoamGrenade
     - id: PlushieLizardJobChiefengineer
       prob: 0.02
+    - id: WeaponLauncherRocketCE # funky #better not miss!
+    - id: CartridgeRocketSingulo #woops missed
+    - id: CartridgeRocketSingulo
+    - id: CartridgeRocketSingulo
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
@@ -58,6 +58,26 @@
     - type: StaticPrice
       price: 20
 
+- type: entity
+  parent: [BaseItem, BaseCommandContraband]
+  id: CartridgeRocketSingulo
+  name: singularity buster grenade
+  description: A 1.5 warhead designed for the singularity buster. It's unusually light.
+  components:
+    - type: Tag
+      tags:
+        - CartridgeRocketSingulo
+    - type: Item
+      size: Small
+    - type: CartridgeAmmo
+      proto: BulletRocketSingulo
+      deleteOnSpawn: true
+    - type: Sprite
+      sprite: Objects/Weapons/Guns/Ammunition/Explosives/explosives.rsi
+      state: rpg
+    - type: StaticPrice
+      price: 20
+
 # Grenades
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -476,3 +476,38 @@
   components:
   - type: BallisticAmmoProvider
     proto: ImmovableRodSlow
+
+#yes this is literally just the RPG but for singularities only. There's just... too many looses that's impossible to fix, even with particle decels. This should help. For teslooses, uh. unless you hit it RIGHT on, you're SOL.
+- type: entity
+  name: singularity buster
+  parent: [ BaseWeaponLauncher, BaseCommandContraband ]
+  id: WeaponLauncherRocketCE
+  suffix: CE
+  description: A specialized rocket launcher that can only shoot singularity-busting rockets filled with negative particles. Try not to miss.
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Launchers/rocket.rsi
+    layers:
+      - state: base
+        map: ["enum.GunVisualLayers.Base"]
+      - state: mag-0
+        map: ["enum.GunVisualLayers.Mag"]
+  - type: Clothing
+    sprite: Objects/Weapons/Guns/Launchers/rocket.rsi
+  - type: Gun
+    fireRate: 0.5
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/rpgfire.ogg
+  - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+        - CartridgeRocketSingulo
+    proto: CartridgeRocketSingulo
+    capacity: 1
+    soundInsert:
+      path: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
+  - type: MagazineVisuals
+    magState: mag
+    steps: 2
+    zeroVisible: false
+  - type: Appearance

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -924,6 +924,31 @@
     energy: 0.5
 
 - type: entity
+  id: BulletRocketSingulo
+  name: singularity buster rocket
+  parent: BaseBulletTrigger
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
+    layers:
+      - state: frag
+  - type: ExplodeOnTrigger
+  - type: Explosive #this SHOULDN'T crit anyone #like 15 damage TOPS on direct hit sooo
+    explosionType: Default
+    maxIntensity: 0.5
+    intensitySlope: 0.25
+    totalIntensity: 1
+    maxTileBreak: 1
+  - type: PointLight
+    radius: 3.5
+    color: orange
+    energy: 0.5
+  - type: SinguloFood #3 shots to kill a T4 singularity fed with the singulo beacons. above that, uh. it's wraps. go get a particle decelerator and finish the job
+    energy: -400
+    energyFactor: 0.97
+
+- type: entity
   id: BulletGrenadeBaton
   name: baton grenade
   parent: BaseBullet

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -427,6 +427,9 @@
 - type: Tag
   id: CartridgeRocket # Specialty ammo for WeaponLauncherRocket.
 
+- type: Tag
+  id: CartridgeRocketSingulo # Special ammo for the singularity buster
+
 #endregion
 
 - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Functionally, an RPG that deals at MOST 15 damage total on direct hit without armor, however kills an admin spawned tesla in one shot, can kill a T4 singularity filled with singularity beacons in 3 shots. CE gets the singularity buster+3 spare grenades in their locker.
<!-- What did you change? -->

## Why / Balance
Honestly, yes looses are cool and all, but engineering always not being able to re-contain it saddens me deeply. Since it's forky, figured I change up how engi gets to kill the loose, instead of PDs. CEs now get this, which should help out what was originally an evac immediately, oh no everyone's dead, into an evac immediately, but engineering contained the loose. The CE can also just fumble these shots. As someone would say, this would make for hype and aura moments. Theoretically, if this impact is *really* good, could perhaps make looses easier to happen, as a counterbalance. MAYBE make it a syndicate steal objective, for situations where the thief has a choice between saving the station or doing their objective. Could probably lead to some interesting rounds.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
YAML+an added tag
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Added the singularity buster! Find it in the CE's locker! It comes with 3 spare grenades. Don't miss.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
