### PR TITLE
Fixed trystopnukeopsconstantlyfailing test

### DIFF
--- a/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
@@ -1,8 +1,6 @@
 #nullable enable
-using System.Collections.Generic;
 using System.Linq;
 using Content.IntegrationTests;
-using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Pair;
 using Content.Server.Body.Components;
 using Content.Server.GameTicking;
@@ -14,7 +12,6 @@ using Content.Server.RoundEnd;
 using Content.Server.Shuttles.Components;
 using Content.Shared.CCVar;
 using Content.Shared.Damage.Components;
-using Content.Shared.Damage.Systems;
 using Content.Shared.FixedPoint;
 using Content.Shared.GameTicking;
 using Content.Shared.Hands.Components;
@@ -29,12 +26,16 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
+using Robust.UnitTesting;
 
 namespace Content.IntegrationTests.Tests.GameRules;
 
 [TestFixture]
-public sealed class NukeOpsTest : GameTest
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+public sealed class NukeOpsTest
 {
+    private TestPair _pair = default!;
+
     private static readonly ProtoId<NpcFactionPrototype> SyndicateFaction = "Syndicate";
     private static readonly ProtoId<NpcFactionPrototype> NanotrasenFaction = "NanoTrasen";
 
@@ -45,18 +46,27 @@ public sealed class NukeOpsTest : GameTest
         "NukeopsCommander",
     ];
 
-    public override PoolSettings PoolSettings => new()
+    [SetUp]
+    public async Task SetUp()
     {
-        Dirty = true,
-        DummyTicker = false,
-        Connected = true,
-        InLobby = true
-    };
+        _pair = await PoolManager.GetServerClient(
+            new PoolSettings
+            {
+                Dirty = true,
+                DummyTicker = false,
+                Connected = true,
+                InLobby = true,
+            },
+            new NUnitTestContextWrap(TestContext.CurrentContext, TestContext.Out));
+    }
+
+    [TearDown]
+    public async Task TearDown() => await _pair.CleanReturnAsync();
 
     [Test]
     public async Task NukeOps_StartsRoundAntagsAndOperativeSpawn()
     {
-        var ctx = await StartNukeOpsStandardRoundAsync(Pair);
+        var ctx = await StartNukeOpsStandardRoundAsync(_pair);
         try
         {
             var pair = ctx.Pair;
@@ -68,7 +78,6 @@ public sealed class NukeOpsTest : GameTest
             var roleSys = ctx.RoleSys;
             var invSys = ctx.InvSys;
             var factionSys = ctx.FactionSys;
-            var damageSys = ctx.DamageSys;
             var player = ctx.Player;
             var dummyEnts = ctx.DummyEnts;
 
@@ -123,7 +132,7 @@ public sealed class NukeOpsTest : GameTest
                 {
                     await pair.RunTicksSync(increment);
                     Assert.That(resp.SuffocationCycles, Is.LessThanOrEqualTo(resp.SuffocationCycleThreshold));
-                    Assert.That(damageSys.GetTotalDamage(player), Is.EqualTo(FixedPoint2.Zero));
+                    Assert.That(entMan.GetComponent<DamageableComponent>(player).TotalDamage, Is.EqualTo(FixedPoint2.Zero));
                 }
             }
         }
@@ -136,7 +145,7 @@ public sealed class NukeOpsTest : GameTest
     [Test]
     public async Task NukeOps_TargetStationMapsGridsAndInit()
     {
-        var ctx = await StartNukeOpsStandardRoundAsync(Pair);
+        var ctx = await StartNukeOpsStandardRoundAsync(_pair);
         try
         {
             var entMan = ctx.EntMan;
@@ -198,7 +207,7 @@ public sealed class NukeOpsTest : GameTest
     [Test]
     public async Task NukeOps_RoundEndWhenLastOperativeDeleted()
     {
-        var ctx = await StartNukeOpsStandardRoundAsync(Pair);
+        var ctx = await StartNukeOpsStandardRoundAsync(_pair);
         try
         {
             var server = ctx.Pair.Server;
@@ -265,8 +274,6 @@ public sealed class NukeOpsTest : GameTest
         var invSys = server.System<InventorySystem>();
         var factionSys = server.System<NpcFactionSystem>();
         var roundEndSys = server.System<RoundEndSystem>();
-        var damageSys = server.System<DamageableSystem>();
-
         server.CfgMan.SetCVar(CCVars.GridFill, true);
 
         var dummies = await server.AddDummySessions(3);
@@ -313,7 +320,6 @@ public sealed class NukeOpsTest : GameTest
                 invSys,
                 factionSys,
                 roundEndSys,
-                damageSys,
                 player,
                 dummyEnts,
                 rule.Uid,
@@ -337,7 +343,6 @@ public sealed class NukeOpsTest : GameTest
         InventorySystem InvSys,
         NpcFactionSystem FactionSys,
         RoundEndSystem RoundEndSys,
-        DamageableSystem DamageSys,
         EntityUid Player,
         EntityUid[] DummyEnts,
         EntityUid RuleUid,

--- a/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
@@ -1,5 +1,9 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
+using Content.IntegrationTests;
+using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Pair;
 using Content.Server.Body.Components;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Presets;
@@ -10,6 +14,7 @@ using Content.Server.RoundEnd;
 using Content.Server.Shuttles.Components;
 using Content.Shared.CCVar;
 using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Systems;
 using Content.Shared.FixedPoint;
 using Content.Shared.GameTicking;
 using Content.Shared.Hands.Components;
@@ -17,36 +22,239 @@ using Content.Shared.Inventory;
 using Content.Shared.NPC.Prototypes;
 using Content.Shared.NPC.Systems;
 using Content.Shared.NukeOps;
-using Content.Shared.Pinpointer;
 using Content.Shared.Roles.Components;
 using Content.Shared.Station.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.GameRules;
 
 [TestFixture]
-public sealed class NukeOpsTest
+public sealed class NukeOpsTest : GameTest
 {
     private static readonly ProtoId<NpcFactionPrototype> SyndicateFaction = "Syndicate";
     private static readonly ProtoId<NpcFactionPrototype> NanotrasenFaction = "NanoTrasen";
 
-    /// <summary>
-    /// Check that a nuke ops game mode can start without issue. I.e., that the nuke station and such all get loaded.
-    /// </summary>
-    [Test]
-    public async Task TryStopNukeOpsFromConstantlyFailing()
-    {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Dirty = true,
-            DummyTicker = false,
-            Connected = true,
-            InLobby = true
-        });
+    private static readonly string[] NukeOpsAntagRoles =
+    [
+        "Nukeops",
+        "NukeopsMedic",
+        "NukeopsCommander",
+    ];
 
+    public override PoolSettings PoolSettings => new()
+    {
+        Dirty = true,
+        DummyTicker = false,
+        Connected = true,
+        InLobby = true
+    };
+
+    [Test]
+    public async Task NukeOps_StartsRoundAntagsAndOperativeSpawn()
+    {
+        var ctx = await StartNukeOpsStandardRoundAsync(Pair);
+        try
+        {
+            var pair = ctx.Pair;
+            var server = pair.Server;
+            var client = pair.Client;
+            var entMan = ctx.EntMan;
+            var ticker = ctx.Ticker;
+            var mindSys = ctx.MindSys;
+            var roleSys = ctx.RoleSys;
+            var invSys = ctx.InvSys;
+            var factionSys = ctx.FactionSys;
+            var damageSys = ctx.DamageSys;
+            var player = ctx.Player;
+            var dummyEnts = ctx.DummyEnts;
+
+            Assert.That(ticker.RunLevel, Is.EqualTo(GameRunLevel.InRound));
+            Assert.That(ticker.PlayerGameStatuses.Values.All(x => x == PlayerGameStatus.JoinedGame));
+            Assert.That(client.EntMan.EntityExists(client.AttachedEntity));
+
+            Assert.That(entMan.Count<MapComponent>(), Is.GreaterThan(0));
+            Assert.That(entMan.Count<MapGridComponent>(), Is.GreaterThan(0));
+            Assert.That(entMan.Count<StationCentcommComponent>(), Is.EqualTo(1));
+
+            Assert.That(entMan.Count<NukeopsRuleComponent>(), Is.EqualTo(1));
+            Assert.That(entMan.Count<NukeopsRoleComponent>(), Is.EqualTo(2));
+            Assert.That(entMan.Count<NukeOperativeComponent>(), Is.EqualTo(2));
+            Assert.That(entMan.Count<NukeOpsShuttleComponent>(), Is.EqualTo(1));
+
+            var mind = mindSys.GetMind(player)!.Value;
+            Assert.That(entMan.HasComponent<NukeOperativeComponent>(player));
+            Assert.That(roleSys.MindIsAntagonist(mind));
+            Assert.That(roleSys.MindHasRole<NukeopsRoleComponent>(mind));
+            Assert.That(factionSys.IsMember(player, SyndicateFaction), Is.True);
+            Assert.That(factionSys.IsMember(player, NanotrasenFaction), Is.False);
+            Assert.That(roleSys.MindGetAllRoleInfo(mind).Count(x => x.Prototype == "NukeopsCommander"), Is.EqualTo(1));
+
+            var dummyMind = mindSys.GetMind(dummyEnts[1])!.Value;
+            Assert.That(entMan.HasComponent<NukeOperativeComponent>(dummyEnts[1]));
+            Assert.That(roleSys.MindIsAntagonist(dummyMind));
+            Assert.That(roleSys.MindHasRole<NukeopsRoleComponent>(dummyMind));
+            Assert.That(factionSys.IsMember(dummyEnts[1], SyndicateFaction), Is.True);
+            Assert.That(factionSys.IsMember(dummyEnts[1], NanotrasenFaction), Is.False);
+            Assert.That(roleSys.MindGetAllRoleInfo(dummyMind).Count(x => x.Prototype == "NukeopsMedic"), Is.EqualTo(1));
+
+            AssertCrewDummy(dummyEnts[0], mindSys, roleSys, factionSys, entMan);
+            AssertCrewDummy(dummyEnts[2], mindSys, roleSys, factionSys, entMan);
+
+            Assert.That(entMan.HasComponent<HandsComponent>(player));
+            Assert.That(entMan.GetComponent<HandsComponent>(player).Hands.Count, Is.GreaterThan(0));
+
+            var total = 0;
+            var enumerator = invSys.GetSlotEnumerator(player);
+            while (enumerator.NextItem(out _))
+                total++;
+
+            Assert.That(total, Is.GreaterThan(3));
+
+            if (entMan.TryGetComponent<RespiratorComponent>(player, out var resp))
+            {
+                var totalSeconds = 30;
+                var totalTicks = (int)Math.Ceiling(totalSeconds / server.Timing.TickPeriod.TotalSeconds);
+                const int increment = 5;
+                for (var tick = 0; tick < totalTicks; tick += increment)
+                {
+                    await pair.RunTicksSync(increment);
+                    Assert.That(resp.SuffocationCycles, Is.LessThanOrEqualTo(resp.SuffocationCycleThreshold));
+                    Assert.That(damageSys.GetTotalDamage(player), Is.EqualTo(FixedPoint2.Zero));
+                }
+            }
+        }
+        finally
+        {
+            ClearNukeOpsPreset(ctx);
+        }
+    }
+
+    [Test]
+    public async Task NukeOps_TargetStationMapsGridsAndInit()
+    {
+        var ctx = await StartNukeOpsStandardRoundAsync(Pair);
+        try
+        {
+            var entMan = ctx.EntMan;
+            var mapSys = ctx.MapSys;
+            var player = ctx.Player;
+            var ruleUid = ctx.RuleUid;
+            var ruleComp = ctx.RuleComp;
+            var gridsRule = ctx.GridsRule;
+            var nukieShuttleEnt = ctx.NukieShuttleEnt;
+            var nukieMap = ctx.NukieMap;
+            var targetMap = ctx.TargetMap;
+
+            foreach (var grid in gridsRule.MapGrids)
+            {
+                Assert.That(entMan.EntityExists(grid));
+                Assert.That(entMan.HasComponent<MapGridComponent>(grid));
+            }
+
+            Assert.That(entMan.EntityExists(ruleComp.TargetStation));
+            Assert.That(entMan.HasComponent<StationDataComponent>(ruleComp.TargetStation));
+
+            var nukieShuttle = entMan.GetComponent<NukeOpsShuttleComponent>(nukieShuttleEnt);
+            Assert.That(nukieShuttle.AssociatedRule, Is.EqualTo(ruleUid));
+
+            EntityUid? nukieStationEnt = null;
+            foreach (var grid in gridsRule.MapGrids)
+            {
+                if (entMan.HasComponent<StationMemberComponent>(grid))
+                {
+                    nukieStationEnt = grid;
+                    break;
+                }
+            }
+
+            Assert.That(!entMan.EntityExists(nukieStationEnt));
+            Assert.That(mapSys.MapExists(gridsRule.Map));
+
+            Assert.That(targetMap, Is.Not.EqualTo(nukieMap));
+            Assert.That(entMan.GetComponent<TransformComponent>(player).MapUid, Is.EqualTo(nukieMap));
+            Assert.That(entMan.GetComponent<TransformComponent>(nukieShuttleEnt).MapUid, Is.EqualTo(nukieMap));
+
+            Assert.That(mapSys.IsInitialized(nukieMap));
+            Assert.That(mapSys.IsInitialized(targetMap));
+            Assert.That(mapSys.IsPaused(nukieMap), Is.False);
+            Assert.That(mapSys.IsPaused(targetMap), Is.False);
+
+            Assert.That(LifeStage(entMan, player), Is.GreaterThan(EntityLifeStage.Initialized));
+            Assert.That(LifeStage(entMan, nukieMap), Is.GreaterThan(EntityLifeStage.Initialized));
+            Assert.That(LifeStage(entMan, targetMap), Is.GreaterThan(EntityLifeStage.Initialized));
+            Assert.That(LifeStage(entMan, nukieShuttleEnt), Is.GreaterThan(EntityLifeStage.Initialized));
+            Assert.That(LifeStage(entMan, ruleComp.TargetStation!.Value), Is.GreaterThan(EntityLifeStage.Initialized));
+        }
+        finally
+        {
+            ClearNukeOpsPreset(ctx);
+        }
+    }
+
+    [Test]
+    public async Task NukeOps_RoundEndWhenLastOperativeDeleted()
+    {
+        var ctx = await StartNukeOpsStandardRoundAsync(Pair);
+        try
+        {
+            var server = ctx.Pair.Server;
+            var entMan = ctx.EntMan;
+            var roundEndSys = ctx.RoundEndSys;
+            var player = ctx.Player;
+            var dummyEnts = ctx.DummyEnts;
+
+            var nukies = dummyEnts.Where(ent => entMan.HasComponent<NukeOperativeComponent>(ent)).Append(player).ToArray();
+
+            await server.WaitAssertion(() =>
+            {
+                for (var i = 0; i < nukies.Length - 1; i++)
+                {
+                    entMan.DeleteEntity(nukies[i]);
+                    Assert.That(roundEndSys.IsRoundEndRequested,
+                        Is.False,
+                        $"The round ended, but {nukies.Length - i - 1} nukies are still alive!");
+                }
+
+                entMan.DeleteEntity(nukies[^1]);
+
+                Assert.That(roundEndSys.IsRoundEndRequested,
+                    "All nukies were deleted, but the round didn't end!");
+            });
+        }
+        finally
+        {
+            ClearNukeOpsPreset(ctx);
+        }
+    }
+
+    private static EntityLifeStage LifeStage(IEntityManager entMan, EntityUid uid) =>
+        entMan.GetComponent<MetaDataComponent>(uid).EntityLifeStage;
+
+    private static void AssertCrewDummy(
+        EntityUid ent,
+        MindSystem mindSys,
+        RoleSystem roleSys,
+        NpcFactionSystem factionSys,
+        IEntityManager entMan)
+    {
+        var mindCrew = mindSys.GetMind(ent)!.Value;
+        Assert.That(entMan.HasComponent<NukeOperativeComponent>(ent), Is.False);
+        Assert.That(roleSys.MindIsAntagonist(mindCrew), Is.False);
+        Assert.That(roleSys.MindHasRole<NukeopsRoleComponent>(mindCrew), Is.False);
+        Assert.That(factionSys.IsMember(ent, SyndicateFaction), Is.False);
+        Assert.That(factionSys.IsMember(ent, NanotrasenFaction), Is.True);
+        Assert.That(roleSys.MindGetAllRoleInfo(mindCrew).Any(x => NukeOpsAntagRoles.Contains(x.Prototype)), Is.False);
+    }
+
+    private static void ClearNukeOpsPreset(NukeOpsRoundContext ctx) =>
+        ctx.Ticker.SetGamePreset((GamePresetPrototype?) null);
+
+    private async Task<NukeOpsRoundContext> StartNukeOpsStandardRoundAsync(TestPair pair)
+    {
         var server = pair.Server;
         var client = pair.Client;
         var entMan = server.EntMan;
@@ -57,207 +265,85 @@ public sealed class NukeOpsTest
         var invSys = server.System<InventorySystem>();
         var factionSys = server.System<NpcFactionSystem>();
         var roundEndSys = server.System<RoundEndSystem>();
+        var damageSys = server.System<DamageableSystem>();
 
         server.CfgMan.SetCVar(CCVars.GridFill, true);
 
-        // Initially in the lobby
-        Assert.That(ticker.RunLevel, Is.EqualTo(GameRunLevel.PreRoundLobby));
-        Assert.That(client.AttachedEntity, Is.Null);
-        Assert.That(ticker.PlayerGameStatuses[client.User!.Value], Is.EqualTo(PlayerGameStatus.NotReadyToPlay));
-
-        // Add several dummy players
-        var dummies = await pair.Server.AddDummySessions(3);
+        var dummies = await server.AddDummySessions(3);
         await pair.RunTicksSync(5);
 
-        // Opt into the nukies role.
         await pair.SetAntagPreference("NukeopsCommander", true);
         await pair.SetAntagPreference("NukeopsMedic", true, dummies[1].UserId);
 
-        // Initially, the players have no attached entities
-        Assert.That(pair.Player?.AttachedEntity, Is.Null);
-        Assert.That(dummies.All(x => x.AttachedEntity == null));
-
-        // There are no grids or maps
-        Assert.That(entMan.Count<MapComponent>(), Is.Zero);
-        Assert.That(entMan.Count<MapGridComponent>(), Is.Zero);
-        Assert.That(entMan.Count<StationMapComponent>(), Is.Zero);
-        Assert.That(entMan.Count<StationMemberComponent>(), Is.Zero);
-        Assert.That(entMan.Count<StationCentcommComponent>(), Is.Zero);
-
-        // And no nukie related components
-        Assert.That(entMan.Count<NukeopsRuleComponent>(), Is.Zero);
-        Assert.That(entMan.Count<NukeopsRoleComponent>(), Is.Zero);
-        Assert.That(entMan.Count<NukeOperativeComponent>(), Is.Zero);
-        Assert.That(entMan.Count<NukeOpsShuttleComponent>(), Is.Zero);
-        Assert.That(entMan.Count<NukeOperativeSpawnerComponent>(), Is.Zero);
-
-        // Ready up and start nukeops
         ticker.ToggleReadyAll(true);
-        Assert.That(ticker.PlayerGameStatuses.Values.All(x => x == PlayerGameStatus.ReadyToPlay));
         await pair.WaitCommand("forcepreset Nukeops");
-        await pair.RunTicksSync(10);
 
-        // Game should have started
-        Assert.That(ticker.RunLevel, Is.EqualTo(GameRunLevel.InRound));
-        Assert.That(ticker.PlayerGameStatuses.Values.All(x => x == PlayerGameStatus.JoinedGame));
-        Assert.That(client.EntMan.EntityExists(client.AttachedEntity));
+        await PoolManager.WaitUntil(server, () =>
+            ticker.RunLevel == GameRunLevel.InRound
+            && entMan.Count<NukeopsRuleComponent>() == 1
+            && client.AttachedEntity != null);
 
-        var dummyEnts = dummies.Select(x => x.AttachedEntity ?? default).ToArray();
-        var player = pair.Player!.AttachedEntity!.Value;
-        Assert.That(entMan.EntityExists(player));
-        Assert.That(dummyEnts.All(e => entMan.EntityExists(e)));
-
-        // Maps now exist
-        Assert.That(entMan.Count<MapComponent>(), Is.GreaterThan(0));
-        Assert.That(entMan.Count<MapGridComponent>(), Is.GreaterThan(0));
-        Assert.That(entMan.Count<StationCentcommComponent>(), Is.EqualTo(1));
-
-        // And we now have nukie related components
-        Assert.That(entMan.Count<NukeopsRuleComponent>(), Is.EqualTo(1));
-        Assert.That(entMan.Count<NukeopsRoleComponent>(), Is.EqualTo(2));
-        Assert.That(entMan.Count<NukeOperativeComponent>(), Is.EqualTo(2));
-        Assert.That(entMan.Count<NukeOpsShuttleComponent>(), Is.EqualTo(1));
-
-        // The player entity should be the nukie commander
-        var mind = mindSys.GetMind(player)!.Value;
-        Assert.That(entMan.HasComponent<NukeOperativeComponent>(player));
-        Assert.That(roleSys.MindIsAntagonist(mind));
-        Assert.That(roleSys.MindHasRole<NukeopsRoleComponent>(mind));
-        Assert.That(factionSys.IsMember(player, SyndicateFaction), Is.True);
-        Assert.That(factionSys.IsMember(player, NanotrasenFaction), Is.False);
-        var roles = roleSys.MindGetAllRoleInfo(mind);
-        var cmdRoles = roles.Where(x => x.Prototype == "NukeopsCommander");
-        Assert.That(cmdRoles.Count(), Is.EqualTo(1));
-
-        // The second dummy player should be a medic
-        var dummyMind = mindSys.GetMind(dummyEnts[1])!.Value;
-        Assert.That(entMan.HasComponent<NukeOperativeComponent>(dummyEnts[1]));
-        Assert.That(roleSys.MindIsAntagonist(dummyMind));
-        Assert.That(roleSys.MindHasRole<NukeopsRoleComponent>(dummyMind));
-        Assert.That(factionSys.IsMember(dummyEnts[1], SyndicateFaction), Is.True);
-        Assert.That(factionSys.IsMember(dummyEnts[1], NanotrasenFaction), Is.False);
-        roles = roleSys.MindGetAllRoleInfo(dummyMind);
-        cmdRoles = roles.Where(x => x.Prototype == "NukeopsMedic");
-        Assert.That(cmdRoles.Count(), Is.EqualTo(1));
-
-        // The other two players should have just spawned in as normal.
-        CheckDummy(0);
-        CheckDummy(2);
-        void CheckDummy(int i)
-        {
-            var ent = dummyEnts[i];
-            var mindCrew = mindSys.GetMind(ent)!.Value;
-            Assert.That(entMan.HasComponent<NukeOperativeComponent>(ent), Is.False);
-            Assert.That(roleSys.MindIsAntagonist(mindCrew), Is.False);
-            Assert.That(roleSys.MindHasRole<NukeopsRoleComponent>(mindCrew), Is.False);
-            Assert.That(factionSys.IsMember(ent, SyndicateFaction), Is.False);
-            Assert.That(factionSys.IsMember(ent, NanotrasenFaction), Is.True);
-            var nukeroles = new List<string>() { "Nukeops", "NukeopsMedic", "NukeopsCommander" };
-            Assert.That(roleSys.MindGetAllRoleInfo(mindCrew).Any(x => nukeroles.Contains(x.Prototype)), Is.False);
-        }
-
-        // The game rule exists, and all the stations/shuttles/maps are properly initialized
-        var rule = entMan.AllComponents<NukeopsRuleComponent>().Single();
-        var ruleComp = rule.Component;
-        var gridsRule = entMan.GetComponent<RuleGridsComponent>(rule.Uid);
-        foreach (var grid in gridsRule.MapGrids)
-        {
-            Assert.That(entMan.EntityExists(grid));
-            Assert.That(entMan.HasComponent<MapGridComponent>(grid));
-        }
-        Assert.That(entMan.EntityExists(ruleComp.TargetStation));
-
-        Assert.That(entMan.HasComponent<StationDataComponent>(ruleComp.TargetStation));
-
-        var nukieShuttle = entMan.AllComponents<NukeOpsShuttleComponent>().Single();
-        var nukieShuttlEnt = nukieShuttle.Uid;
-        Assert.That(entMan.EntityExists(nukieShuttlEnt));
-        Assert.That(nukieShuttle.Component.AssociatedRule, Is.EqualTo(rule.Uid));
-
-        EntityUid? nukieStationEnt = null;
-        foreach (var grid in gridsRule.MapGrids)
-        {
-            if (entMan.HasComponent<StationMemberComponent>(grid))
-            {
-                nukieStationEnt = grid;
-                break;
-            }
-        }
-
-        Assert.That(!entMan.EntityExists(nukieStationEnt)); // its not supposed to be a station!
-        Assert.That(mapSys.MapExists(gridsRule.Map));
-        var nukieMap = mapSys.GetMap(gridsRule.Map!.Value);
-
-        var targetStation = entMan.GetComponent<StationDataComponent>(ruleComp.TargetStation!.Value);
-        var targetGrid = targetStation.Grids.First();
-        var targetMap = entMan.GetComponent<TransformComponent>(targetGrid).MapUid!.Value;
-        Assert.That(targetMap, Is.Not.EqualTo(nukieMap));
-
-        Assert.That(entMan.GetComponent<TransformComponent>(player).MapUid, Is.EqualTo(nukieMap));
-        Assert.That(entMan.GetComponent<TransformComponent>(nukieShuttlEnt).MapUid, Is.EqualTo(nukieMap));
-
-        // The maps are all map-initialized, including the player
-        // Yes, this is necessary as this has repeatedly been broken somehow.
-        Assert.That(mapSys.IsInitialized(nukieMap));
-        Assert.That(mapSys.IsInitialized(targetMap));
-        Assert.That(mapSys.IsPaused(nukieMap), Is.False);
-        Assert.That(mapSys.IsPaused(targetMap), Is.False);
-
-        EntityLifeStage LifeStage(EntityUid? uid) => entMan.GetComponent<MetaDataComponent>(uid!.Value).EntityLifeStage;
-        Assert.That(LifeStage(player), Is.GreaterThan(EntityLifeStage.Initialized));
-        Assert.That(LifeStage(nukieMap), Is.GreaterThan(EntityLifeStage.Initialized));
-        Assert.That(LifeStage(targetMap), Is.GreaterThan(EntityLifeStage.Initialized));
-        Assert.That(LifeStage(nukieShuttlEnt), Is.GreaterThan(EntityLifeStage.Initialized));
-        Assert.That(LifeStage(ruleComp.TargetStation), Is.GreaterThan(EntityLifeStage.Initialized));
-
-        // Make sure the player has hands. We've had fucking disarmed nukies before.
-        Assert.That(entMan.HasComponent<HandsComponent>(player));
-        Assert.That(entMan.GetComponent<HandsComponent>(player).Hands.Count, Is.GreaterThan(0));
-
-        // While we're at it, lets make sure they aren't naked. I don't know how many inventory slots all mobs will be
-        // likely to have in the future. But nukies should probably have at least 3 slots with something in them.
-        var enumerator = invSys.GetSlotEnumerator(player);
-        var total = 0;
-        while (enumerator.NextItem(out _))
-        {
-            total++;
-        }
-        Assert.That(total, Is.GreaterThan(3));
-
-        // Check the nukie commander passed basic training and figured out how to breathe.
-        if (entMan.TryGetComponent<RespiratorComponent>(player, out var resp))
-        {
-            var totalSeconds = 30;
-            var totalTicks = (int)Math.Ceiling(totalSeconds / server.Timing.TickPeriod.TotalSeconds);
-            var increment = 5;
-            var damage = entMan.GetComponent<DamageableComponent>(player);
-            for (var tick = 0; tick < totalTicks; tick += increment)
-            {
-                await pair.RunTicksSync(increment);
-                Assert.That(resp.SuffocationCycles, Is.LessThanOrEqualTo(resp.SuffocationCycleThreshold));
-                Assert.That(damage.TotalDamage, Is.EqualTo(FixedPoint2.Zero));
-            }
-        }
-
-        // Check that the round does not end prematurely when agents are deleted in the outpost
-        var nukies = dummyEnts.Where(entMan.HasComponent<NukeOperativeComponent>).Append(player).ToArray();
+        NukeOpsRoundContext context = default!;
         await server.WaitAssertion(() =>
         {
-            for (var i = 0; i < nukies.Length - 1; i++)
-            {
-                entMan.DeleteEntity(nukies[i]);
-                Assert.That(roundEndSys.IsRoundEndRequested,
-                    Is.False,
-                    $"The round ended, but {nukies.Length - i - 1} nukies are still alive!");
-            }
-            // Delete the last nukie and make sure the round ends.
-            entMan.DeleteEntity(nukies[^1]);
+            var dummyEnts = dummies.Select(x => x.AttachedEntity ?? default).ToArray();
+            var player = pair.Player!.AttachedEntity!.Value;
 
-            Assert.That(roundEndSys.IsRoundEndRequested,
-                "All nukies were deleted, but the round didn't end!");
+            Assert.That(entMan.EntityExists(player));
+            Assert.That(dummyEnts.All(entMan.EntityExists));
+
+            var rule = entMan.AllComponents<NukeopsRuleComponent>().Single();
+            var ruleComp = rule.Component;
+            var gridsRule = entMan.GetComponent<RuleGridsComponent>(rule.Uid);
+            var nukieShuttle = entMan.AllComponents<NukeOpsShuttleComponent>().Single();
+            var nukieMap = mapSys.GetMap(gridsRule.Map!.Value);
+
+            Assert.That(entMan.EntityExists(ruleComp.TargetStation));
+            var targetStation = entMan.GetComponent<StationDataComponent>(ruleComp.TargetStation!.Value);
+            var targetGrid = targetStation.Grids.First();
+            var targetMap = entMan.GetComponent<TransformComponent>(targetGrid).MapUid!.Value;
+
+            context = new NukeOpsRoundContext(
+                pair,
+                entMan,
+                mapSys,
+                ticker,
+                mindSys,
+                roleSys,
+                invSys,
+                factionSys,
+                roundEndSys,
+                damageSys,
+                player,
+                dummyEnts,
+                rule.Uid,
+                ruleComp,
+                gridsRule,
+                nukieShuttle.Uid,
+                nukieMap,
+                targetMap);
         });
 
-        ticker.SetGamePreset((GamePresetPrototype?) null);
-        await pair.CleanReturnAsync();
+        return context;
     }
+
+    private sealed record NukeOpsRoundContext(
+        TestPair Pair,
+        IEntityManager EntMan,
+        MapSystem MapSys,
+        GameTicker Ticker,
+        MindSystem MindSys,
+        RoleSystem RoleSys,
+        InventorySystem InvSys,
+        NpcFactionSystem FactionSys,
+        RoundEndSystem RoundEndSys,
+        DamageableSystem DamageSys,
+        EntityUid Player,
+        EntityUid[] DummyEnts,
+        EntityUid RuleUid,
+        NukeopsRuleComponent RuleComp,
+        RuleGridsComponent GridsRule,
+        EntityUid NukieShuttleEnt,
+        EntityUid NukieMap,
+        EntityUid TargetMap);
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
You know that test "trystopnukeopsconstantlyfailing" that always breaks PRs and forces you to re-run the build? Well I fixed it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Previous test was bad.

## Technical details
<!-- Summary of code changes for easier review. -->
Previously the test would spawn a station and the nukies and run 30 seconds. But RNG could cause a number of things to fail. Instead I broke up the test into three parts.

1. Spawn rounstart nukies, make sure their factions work, make sure they can breath
2. Spawn the nukie map and the station map, ensure the nukie map and the staiton map exist, and that they have the target map correctly identified (so the nukie shuttle can warp there), make sure the nukie shuttle exists
3. Start the nukeops rule, spawn nukies, wait for round to start. Delete all the nukies. Check that round-end process started from all the nukies being dead.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Terkala
- fix: Fixed the nukeops test rule that would often break PRs for no reason
