### PR TITLE
PDA for Pun Pun!

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -98,7 +98,7 @@
     head: ClothingHeadHatTophat
     ears: ClothingHeadsetService
     jumpsuit: ClothingUniformJumpsuitJacketMonkey
-    id: PunPunIDCard
+    id: PunPunPDA
 
 - type: startingGear
   id: MobPollyGear

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/pda.yml
@@ -2,7 +2,7 @@
   parent: BartenderPDA
   id: PunPunPDA
   name: Pun Pun PDA
-  description: Smells like beer, bananas and mischief.
+  description: Smells like alcohol and mischief.
   components:
   - type: Pda
     id: PunPunIDCard

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/pda.yml
@@ -1,0 +1,17 @@
+- type: entity
+  parent: BartenderPDA
+  id: PunPunPDA
+  name: Pun Pun PDA
+  description: Smells like beer, bananas and mischief.
+  components:
+  - type: Pda
+    id: PunPunIDCard
+  - type: Appearance
+    appearanceDataInit:
+     enum.PdaVisuals.PdaType:
+       !type:String
+       pda-bartender
+  - type: PdaBorderColor
+    borderColor: "#333333"
+  - type: Icon
+    state: pda-bartender


### PR DESCRIPTION
## About the PR
Gave Pun Pun a roundstart PDA rather than just an ID.

## Why / Balance
Further solidifies Pun Pun as a crewmember with a PDA. I don't see why Pun wouldn't have one given his status as a NanoTrasen hired bartender and an honourable member of the monkey society.

This also allows for slightly easier communication via Nanotask and Nanochat, although I dont see it being used to circumvent monkey-speech any more than just grabbing a pen and paper.

## Technical details
Created a pda.yml file under the existing _Funkystation namespace in Devices prototypes, which currently only has Pun Pun's PDA, a renamed and description edited Bartender PDA that spawns with Pun Pun's ID.

Additionally adjusted misc_startinggear, specificaly MobMonkeyGear, to spawn with said PDA rather than just the ID.

## Media
![punpunpda.png](https://github.com/user-attachments/assets/4dc610a9-ec06-4860-8e23-2e793fc34d1e)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.

## License
MIT

**Changelog**
:cl:
- add: Added Pun Pun PDA entity.
- tweak: Changed Pun Pun's starting gear to provide his PDA rather than just his ID.
