### PR TITLE
Hyperoxia

### DIFF
--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -121,6 +121,16 @@ public sealed class RespiratorSystem : EntitySystem
                 continue;
             }
 
+            if (respirator.Saturation > 2)
+            {
+                // todo make respirator.HyperoxiaThreshold variable real, gotta learn more about actual C code before I can continue with this
+                // this could definitely be something cooler than normal suffocation
+                TakeSuffocationDamage((uid, respirator));
+                TakeSuffocationDamage((uid, respirator)); //hope this overpowers oxygen/nitrogen, so there's real issue in well, hyperoxia
+                respirator.SuffocationCycles += 1;
+                continue;
+            }
+
             StopSuffocation((uid, respirator));
             respirator.SuffocationCycles = 0;
         }

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -121,7 +121,7 @@ public sealed class RespiratorSystem : EntitySystem
                 continue;
             }
 
-            if (respirator.Saturation > 2)
+            if (respirator.Saturation > 4)
             {
                 // todo make respirator.HyperoxiaThreshold variable real, gotta learn more about actual C code before I can continue with this
                 // this could definitely be something cooler than normal suffocation


### PR DESCRIPTION


<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Hyperoxia now exists, with using dummy code from @Komonighub. There are some todos, like making the hyperoxia threshold actually well, changing according to the lung, but I haven't learnt enough about real and actual coding yet.
<!-- What did you change? -->

## Why / Balance
There should be a drawback to breathing too much oxygen, so people will have to actually set-up the ratio with precision instead of well, just being able to do so. Also parity to real life.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
Just added an if oxysaturation > 4 into the code, if so, take suffocation damage twice, then increase a cycle of suffocation.
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Xcybitt
- add: Added hyperoxia. Be wary not to oversaturate yourself with oxygen/nitrogen!
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
