### PR TITLE
Fix gloves description

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/job.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/job.yml
@@ -138,10 +138,9 @@
       - WireBrush
       - Screwdriver # Funky Start
       - Powerdrill
-      - CleanerGrenade
       - Rag # Funky End
-      components:
       - LightReplacer
+      - CleanerGrenade
   - type: ItemMapper
     sprite: *BeltOverlay
     mapLayers:

--- a/Resources/Prototypes/Entities/Clothing/Belt/job.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/job.yml
@@ -138,10 +138,10 @@
       - WireBrush
       - Screwdriver # Funky Start
       - Powerdrill
+      - CleanerGrenade
       - Rag # Funky End
       components:
       - LightReplacer
-      - CleanerGrenade
   - type: ItemMapper
     sprite: *BeltOverlay
     mapLayers:

--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -205,7 +205,7 @@
   parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsGlovesColorLightBrown
   name: light brown gloves
-  description: _Funkystation/Clothing/Hands/color.rsi
+  description: Regular light brown gloves that do not keep you from frying.
   components:
   - type: Sprite
     sprite: Clothing/Hands/Gloves/Color/color.rsi
@@ -234,7 +234,7 @@
   parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsGlovesColorOrange
   name: orange gloves
-  description: _Funkystation/Clothing/Hands/color.rsi
+  description: Regular orange gloves that do not keep you from frying.
   components:
   - type: Sprite
     sprite: Clothing/Hands/Gloves/Color/color.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
<!-- What did you change? -->
Fixes orange and light brown gloves having the wrong description
Also fixes the janitor belt, cleaning grenades are a tag not a component.

## Test plan
Examine gloves in game

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
<img width="373" height="121" alt="image" src="https://github.com/user-attachments/assets/8f8a51e8-86ee-4dc1-b4c4-c92d86ada95f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Changelog

:cl:
- fix: Fixed some gloves having the wrong description
