### PR TITLE
Fix mesons not being t-rays

### DIFF
--- a/Content.Client/SubFloor/TrayScannerSystem.cs
+++ b/Content.Client/SubFloor/TrayScannerSystem.cs
@@ -67,7 +67,7 @@ public sealed partial class TrayScannerSystem : SharedTrayScannerSystem
         // API is extremely skrungly. If this ever shows up on dottrace ping me and laugh.
         var canSee = false;
 
-        foreach (var item in _inventory.GetHandOrInventoryEntities(player.Value, SlotFlags.POCKET))
+        foreach (var item in _inventory.GetHandOrInventoryEntities(player.Value, SlotFlags.POCKET | SlotFlags.EYES)) // Funky change - check eyes
         {
             if (!_trayScannerQuery.TryGetComponent(item, out var scanner) || !scanner.Enabled)
                 continue;


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
Fixed mesons to actually work

## Technical details
The t-ray system was only checking hands and pockets for items with the t-ray component, not the eyes (it still added the subfloor to PVS, it just didn't then render it). Makes no change to prevent them working as t-ray when handheld.

## Test plan
1. Go somewhere with subfloor wiring or pipes
1. Put on mesons
1. Enable mesons
1. Underfloor items should be visible

## Media
<img width="361" height="245" alt="image" src="https://github.com/user-attachments/assets/0b9e167e-9eec-48be-b3d0-f1f6a3de915f" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->

:cl:
- fix: Fixed mesons not functioning as T-Ray scanners

