### PR TITLE
Hyperoxia Change/Bug Fix

### DIFF
--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -121,13 +121,14 @@ public sealed partial class RespiratorSystem : EntitySystem
                 continue;
             }
 
-            if (respirator.Saturation > 4)
+            // hyperoxia threshold calculation
+            if (respirator.Saturation > (respirator.MaxSaturation * 0.75)) //this should make hyperoxia's threshold scale with maxsaturation, how did i forget about other species
             {
                 // todo make respirator.HyperoxiaThreshold variable real, gotta learn more about actual C code before I can continue with this
                 // this could definitely be something cooler than normal suffocation
                 TakeSuffocationDamage((uid, respirator));
                 TakeSuffocationDamage((uid, respirator)); //hope this overpowers oxygen/nitrogen, so there's real issue in well, hyperoxia
-                respirator.SuffocationCycles += 1;
+                respirator.SuffocationCycles += 2; //2 from 1, should make people gasp
                 continue;
             }
 

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -122,7 +122,7 @@ public sealed partial class RespiratorSystem : EntitySystem
             }
 
             // hyperoxia threshold calculation
-            if (respirator.Saturation > (respirator.MaxSaturation * 0.75)) //this should make hyperoxia's threshold scale with maxsaturation, how did i forget about other species
+            if ((respirator.Saturation > (respirator.MaxSaturation * 0.75)) && (respirator.MaxSaturation < 10)) //this should make hyperoxia's threshold scale with maxsaturation, how did i forget about other species //this way of making slimes immune is ass and should be fixed but i don't have the knowhow yet, so the fix's a bit shit, fix if specieses have diff maxsaturations other than slimes//fuck my chud contrib life
             {
                 // todo make respirator.HyperoxiaThreshold variable real, gotta learn more about actual C code before I can continue with this
                 // this could definitely be something cooler than normal suffocation

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -122,13 +122,25 @@ public sealed partial class RespiratorSystem : EntitySystem
             }
 
             // hyperoxia threshold calculation
+            // this IF statement compares the respirator's saturation to the respirator's max saturation, then checks if the max saturation is lower than 10 or not, which functionally checks if the breather is a slime(yes it's a bad workaround)
             if ((respirator.Saturation > (respirator.MaxSaturation * 0.75)) && (respirator.MaxSaturation < 10)) //this should make hyperoxia's threshold scale with maxsaturation, how did i forget about other species //this way of making slimes immune is ass and should be fixed but i don't have the knowhow yet, so the fix's a bit shit, fix if specieses have diff maxsaturations other than slimes//fuck my chud contrib life
             {
+                //taken from normal suffocation code, this should make the hyperoxia patient gasp so people can know there's an issue
+                // this should tmi try gasping the respirator if the cooldown of the gasp is up
+                if (_gameTiming.CurTime >= respirator.LastGaspEmoteTime + respirator.GaspEmoteCooldown)
+                {
+                    respirator.LastGaspEmoteTime = _gameTiming.CurTime;
+                    _chat.TryEmoteWithChat(uid,
+                        respirator.GaspEmote,
+                        ChatTransmitRange.HideChat,
+                        ignoreActionBlocker: true);
+                }
                 // todo make respirator.HyperoxiaThreshold variable real, gotta learn more about actual C code before I can continue with this
                 // this could definitely be something cooler than normal suffocation
+                // this applies 2* the suffocation damage compared to normal asphyxiation since the respirator will heal airloss damage cause they are breathing their air
                 TakeSuffocationDamage((uid, respirator));
                 TakeSuffocationDamage((uid, respirator)); //hope this overpowers oxygen/nitrogen, so there's real issue in well, hyperoxia
-                respirator.SuffocationCycles += 2; //2 from 1, should make people gasp
+                respirator.SuffocationCycles += 1;
                 continue;
             }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
Made the hyperoxia threshold scale to the species' max saturation, made hyperoxia make you gasp, and functionally made slimes immune to hyperoxia.
<!-- What did you change? -->

## Why / Balance
Bug fix/oversight fix. Slimes breathe too much, and specific numbers are hard to nail, so why not give slimes a buff and a fix. This also should make hyperoxia more dependent on the species, and also indicators for taking damage is good.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
C# tweaking
Also the hyperoxia code now checks if the respirator's max saturation is <10 or not, cause that's the threshold for normal species vs slimes.
<!-- Summary of code changes for easier review. -->

## Test plan
Put an urist mcslimeperson and an urist mchands into a pure nitrogen and oxygen environment with high pressure, then checked the entity's saturation and damage.
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media

<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Xcybitt
- tweak: Made hyperoxia scale with the breather's max saturation.
- tweak: Made slimes not able to take hyperoxia damage.
- tweak: Hyperoxia now makes you gasp!