### PR TITLE
More Reagent Fire CVars, Behaviour Improvements & Fixes

### DIFF
--- a/Content.Server/_Funkystation/ReagentFires/Components/ReagentPuddleFireComponent.cs
+++ b/Content.Server/_Funkystation/ReagentFires/Components/ReagentPuddleFireComponent.cs
@@ -9,27 +9,30 @@ namespace Content.Server._Funkystation.ReagentFires.Components
     public sealed partial class ReagentPuddleFireComponent : Component
     {
         [ViewVariables]
-        public bool OnFire { get; set; } = false;
+        public bool OnFire { get; set; }
 
         [ViewVariables]
         public int FireState { get; set; } = 4;
 
         [ViewVariables]
-        public int Flammability { get; set; } = 0;
+        public int Flammability { get; set; }
 
         [ViewVariables]
-        public bool SelfOxidizing { get; set; } = false;
+        public bool SelfOxidizing { get; set; }
 
         [ViewVariables]
-        public float Accumulator { get; set; } = 0f;
+        public float Accumulator { get; set; }
 
         [ViewVariables]
-        public EntityUid? PlayingStream { get; set; } = null;
+        public EntityUid? PlayingStream { get; set; }
 
         [ViewVariables]
-        public EntityUid? FireEffectEntity { get; set; } = null;
+        public EntityUid? FireEffectEntity { get; set; }
 
         [ViewVariables(VVAccess.ReadWrite), DataField("sound")]
         public SoundSpecifier LoopingSound { get; set; } = new SoundPathSpecifier("/Audio/_Funkystation/Effects/Fire/bigfire.ogg");
+
+        [ViewVariables]
+        public float VolumeFactor { get; set; } = 1f;
     }
 }

--- a/Content.Server/_Funkystation/ReagentFires/Systems/ReagentFireSystem.cs
+++ b/Content.Server/_Funkystation/ReagentFires/Systems/ReagentFireSystem.cs
@@ -4,16 +4,18 @@ using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Decals;
 using Content.Shared._Funkystation.CCVar;
+using Content.Shared._Funkystation.Footprints;
 using Content.Shared._Funkystation.ReagentFires;
 using Content.Shared.Atmos;
-using Content.Shared.Chemistry.Components;
-using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Clothing.Components;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Damage.Systems;
+using Content.Shared.FixedPoint;
 using Content.Shared.Fluids.Components;
+using Content.Shared.Inventory;
 using Content.Shared.Mobs.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
@@ -39,6 +41,7 @@ namespace Content.Server._Funkystation.ReagentFires.Systems
         [Dependency] private IRobustRandom _random = null!;
         [Dependency] private DamageableSystem _damageable = null!;
         [Dependency] private IConfigurationManager _cfg = null!;
+        [Dependency] private InventorySystem _inventory = null!;
 
         private readonly List<EntityUid> _toExtinguish = new();
         private readonly string[] _burntDecals = ["burnt1", "burnt2", "burnt3", "burnt4"];
@@ -46,11 +49,25 @@ namespace Content.Server._Funkystation.ReagentFires.Systems
         private readonly List<(EntityUid Uid, ReagentPuddleFireComponent FireComp, PuddleComponent Puddle, TransformComponent Xform)> _activeFires = new();
         private const string StructuralDamage = "Structural";
         private const string HeatDamage = "Heat";
+        private bool _footprintsFlammable = true;
+        private float _fireProtectionEffectiveness = 1.0f;
+        private bool _volumeScalingEnabled = true;
+        private float _volumeScalingReference = 20f;
+        private float _volumeScalingCurve = 1.5f;
+        private float _smallPuddleBurnThreshold = 1.0f;
+        private float _smallPuddleBurnPercent = 0.5f;
 
         public override void Initialize()
         {
             base.Initialize();
             Subs.CVar(_cfg, ReagentFireCVars.PuddleFireDamageMultiplier, value => _puddleDamageMultiplier = value, true);
+            Subs.CVar(_cfg, ReagentFireCVars.FootprintsFlammable, value => _footprintsFlammable = value, true);
+            Subs.CVar(_cfg, ReagentFireCVars.FireProtectionEffectiveness, value => _fireProtectionEffectiveness = value, true);
+            Subs.CVar(_cfg, ReagentFireCVars.VolumeScalingEnabled, value => _volumeScalingEnabled = value, true);
+            Subs.CVar(_cfg, ReagentFireCVars.VolumeScalingReference, value => _volumeScalingReference = value, true);
+            Subs.CVar(_cfg, ReagentFireCVars.VolumeScalingCurve, value => _volumeScalingCurve = value, true);
+            Subs.CVar(_cfg, ReagentFireCVars.SmallPuddleBurnThreshold, value => _smallPuddleBurnThreshold = value, true);
+            Subs.CVar(_cfg, ReagentFireCVars.SmallPuddleBurnPercent, value => _smallPuddleBurnPercent = value, true);
             SubscribeLocalEvent<TransformComponent, TileExposedEvent>(OnTileExposed);
             SubscribeLocalEvent<PuddleComponent, TileFireEvent>(OnPuddleTileFire);
             SubscribeLocalEvent<ReagentPuddleFireComponent, ComponentShutdown>(OnFireShutdown);
@@ -71,10 +88,31 @@ namespace Content.Server._Funkystation.ReagentFires.Systems
             }
         }
 
+        /// <summary>
+        /// 0-1 intensity factor based on solution volume relative to the reference volume
+        /// Small puddles burn proportionally weaker instead of matching a full puddle
+        /// </summary>
+        private float GetVolumeFactor(FixedPoint2 volume)
+        {
+            if (!_volumeScalingEnabled || _volumeScalingReference <= 0f)
+                return 1f;
+
+            var ratio = Math.Clamp(volume.Float() / _volumeScalingReference, 0f, 1f);
+            return MathF.Pow(ratio, _volumeScalingCurve);
+        }
+
         public void UpdateFire(Entity<PuddleComponent> ent)
         {
             if (ent.Comp.Solution == null)
                 return;
+
+            if (!_footprintsFlammable && HasComp<FootprintComponent>(ent))
+            {
+                if (HasComp<ReagentPuddleFireComponent>(ent))
+                    Extinguish(ent);
+                return;
+            }
+
             var solution = ent.Comp.Solution.Value.Comp.Solution;
             var flammability = solution.GetSolutionFlammability(_prototypeManager);
             var selfOxidizing = solution.IsSolutionSelfOxidizing(_prototypeManager);
@@ -91,10 +129,13 @@ namespace Content.Server._Funkystation.ReagentFires.Systems
             var fireComp = EnsureComp<ReagentPuddleFireComponent>(ent);
             fireComp.Flammability = flammability;
             fireComp.SelfOxidizing = selfOxidizing;
+            fireComp.VolumeFactor = GetVolumeFactor(solution.Volume);
 
-            if (flammability > 10)
+            var effectiveFlammability = flammability * fireComp.VolumeFactor;
+
+            if (effectiveFlammability > 10)
                 fireComp.FireState = 6;
-            else if (flammability > 5)
+            else if (effectiveFlammability > 5)
                 fireComp.FireState = 5;
             else
                 fireComp.FireState = 4;
@@ -126,7 +167,9 @@ namespace Content.Server._Funkystation.ReagentFires.Systems
                 if (!TryComp<ReagentPuddleFireComponent>(puddle, out var fireComp) || fireComp.OnFire)
                     continue;
 
-                var ignitionTemp = 573.15f - (50f * fireComp.Flammability);
+                // use cached volume factor so tiny puddles need a hotter tile to ignite
+                var effectiveFlammability = fireComp.Flammability * fireComp.VolumeFactor;
+                var ignitionTemp = 573.15f - (50f * effectiveFlammability);
                 if (args.Temperature >= ignitionTemp)
                 {
                     Ignite(puddle, fireComp);
@@ -139,7 +182,8 @@ namespace Content.Server._Funkystation.ReagentFires.Systems
         {
             if (TryComp<ReagentPuddleFireComponent>(uid, out var fireComp) && !fireComp.OnFire)
             {
-                var ignitionTemp = 573.15f - (50f * fireComp.Flammability);
+                var effectiveFlammability = fireComp.Flammability * fireComp.VolumeFactor;
+                var ignitionTemp = 573.15f - (50f * effectiveFlammability);
                 if (args.Temperature >= ignitionTemp)
                 {
                     Ignite(uid, fireComp);
@@ -238,6 +282,24 @@ namespace Content.Server._Funkystation.ReagentFires.Systems
             RemComp<ReagentPuddleFireComponent>(uid);
         }
 
+        private float GetFireProtectionReduction(EntityUid uid)
+        {
+            if (!TryComp<InventoryComponent>(uid, out var inv))
+                return 0f;
+
+            var survivalFactor = 1f;
+            foreach (var slot in inv.Slots)
+            {
+                if (!_inventory.TryGetSlotEntity(uid, slot.Name, out var slotEnt, inv))
+                    continue;
+
+                if (TryComp<FireProtectionComponent>(slotEnt, out var protection))
+                    survivalFactor *= (1f - Math.Clamp(protection.Reduction, 0f, 1f));
+            }
+
+            return 1f - survivalFactor;
+        }
+
         public override void Update(float frameTime)
         {
             base.Update(frameTime);
@@ -267,7 +329,9 @@ namespace Content.Server._Funkystation.ReagentFires.Systems
                         var ambientMix = _atmos.GetTileMixture(gridId.Value, null, ambientPos, excite: false);
                         if (ambientMix != null)
                         {
-                            var autoIgnitionTemp = 773.15f - (50f * fireComp.Flammability);
+                            // factor volume into auto-ignition too
+                            var ambientEffectiveFlammability = fireComp.Flammability * fireComp.VolumeFactor;
+                            var autoIgnitionTemp = 773.15f - (50f * ambientEffectiveFlammability);
                             var ambientOxygen = ambientMix.GetMoles(Gas.Oxygen);
 
                             if (ambientMix.Temperature >= autoIgnitionTemp && (fireComp.SelfOxidizing || ambientOxygen > 0.1f))
@@ -310,6 +374,14 @@ namespace Content.Server._Funkystation.ReagentFires.Systems
                 }
 
                 var burnFraction = 0.05f / MathF.Pow(MathF.Max(1f, fireComp.Flammability), 3f);
+
+                var currentVolume = solution.Volume.Float();
+                if (currentVolume > 0f && currentVolume < _smallPuddleBurnThreshold)
+                {
+                    var acceleratedFraction = _smallPuddleBurnPercent / MathF.Max(1f, fireComp.Flammability);
+                    burnFraction = MathF.Max(burnFraction, acceleratedFraction);
+                }
+
                 _solutionContainerSystem.BurnFlammableReagents(puddle.Solution.Value, burnFraction);
 
                 var flammability = solution.GetSolutionFlammability(_prototypeManager);
@@ -322,10 +394,13 @@ namespace Content.Server._Funkystation.ReagentFires.Systems
                 }
 
                 fireComp.SelfOxidizing = selfOxidizing;
+                fireComp.VolumeFactor = GetVolumeFactor(solution.Volume); // refresh cache with live volume
 
-                if (flammability > 10)
+                var effectiveFlammability = flammability * fireComp.VolumeFactor;
+
+                if (effectiveFlammability > 10)
                     fireComp.FireState = 6;
-                else if (flammability > 5)
+                else if (effectiveFlammability > 5)
                     fireComp.FireState = 5;
                 else
                     fireComp.FireState = 4;
@@ -346,23 +421,24 @@ namespace Content.Server._Funkystation.ReagentFires.Systems
 
                 if (tileMix != null)
                 {
-                    var maxTemp = Atmospherics.T0C + 100f * MathF.Pow(flammability, 1.5f);
+                    // use effectiveFlammability for heat output
+                    var maxTemp = Atmospherics.T0C + 100f * MathF.Pow(effectiveFlammability, 1.5f);
                     if (tileMix.Temperature < maxTemp)
                     {
-                        var heatRate = 10f * flammability;
+                        var heatRate = 10f * effectiveFlammability;
                         tileMix.Temperature = MathF.Min(tileMix.Temperature + heatRate, maxTemp);
                     }
 
                     if (!fireComp.SelfOxidizing)
                     {
-                        var burnAmount = MathF.Min(0.2f * flammability, oxygenMoles);
+                        var burnAmount = MathF.Min(0.2f * effectiveFlammability, oxygenMoles);
                         tileMix.AdjustMoles(Gas.Oxygen, -burnAmount);
                         tileMix.AdjustMoles(Gas.CarbonDioxide, burnAmount * 0.6f);
                         tileMix.AdjustMoles(Gas.WaterVapor, burnAmount * 0.8f);
                     }
                     else
                     {
-                        var burnAmount = 0.2f * flammability;
+                        var burnAmount = 0.2f * effectiveFlammability;
                         tileMix.AdjustMoles(Gas.CarbonDioxide, burnAmount * 0.6f);
                         tileMix.AdjustMoles(Gas.WaterVapor, burnAmount * 0.8f);
                     }
@@ -429,13 +505,14 @@ namespace Content.Server._Funkystation.ReagentFires.Systems
                 var structuralProto = _prototypeManager.Index<DamageTypePrototype>(StructuralDamage);
                 var heatProto = _prototypeManager.Index<DamageTypePrototype>(HeatDamage);
 
-                var structuralDamage = new DamageSpecifier(structuralProto, 2f * flammability * _puddleDamageMultiplier);
-                var heatDamage = new DamageSpecifier(heatProto, 2f * flammability * _puddleDamageMultiplier);
+                // use effectiveFlammability for damage output
+                var structuralDamage = new DamageSpecifier(structuralProto, 2f * effectiveFlammability * _puddleDamageMultiplier);
+                var heatDamage = new DamageSpecifier(heatProto, 2f * effectiveFlammability * _puddleDamageMultiplier);
 
                 var totalDamage = structuralDamage + heatDamage;
 
-                var fireVolume = 50f * flammability;
-                var fireEvent = new TileFireEvent(tileMix?.Temperature ?? (Atmospherics.T0C + 50f * flammability), fireVolume);
+                var fireVolume = 50f * effectiveFlammability;
+                var fireEvent = new TileFireEvent(tileMix?.Temperature ?? (Atmospherics.T0C + 50f * effectiveFlammability), fireVolume);
 
                 var xformQuery = GetEntityQuery<TransformComponent>();
                 foreach (var ent in standingEntities)
@@ -452,7 +529,15 @@ namespace Content.Server._Funkystation.ReagentFires.Systems
                     if (HasComp<DamageableComponent>(ent))
                     {
                         var ignoreResistances = !HasComp<MobStateComponent>(ent);
-                        _damageable.TryChangeDamage(ent, totalDamage, ignoreResistances: ignoreResistances);
+
+                        var appliedDamage = totalDamage;
+                        if (!ignoreResistances)
+                        {
+                            var reduction = Math.Clamp(GetFireProtectionReduction(ent) * _fireProtectionEffectiveness, 0f, 1f);
+                            appliedDamage = totalDamage * (1f - reduction);
+                        }
+
+                        _damageable.TryChangeDamage(ent, appliedDamage, ignoreResistances: ignoreResistances);
                     }
 
                     if (Deleted(ent))

--- a/Content.Shared/_Funkystation/CCVar/ReagentFireCVars.cs
+++ b/Content.Shared/_Funkystation/CCVar/ReagentFireCVars.cs
@@ -16,4 +16,46 @@ public sealed class ReagentFireCVars
     /// </summary>
     public static readonly CVarDef<float> PuddleFireDamageMultiplier =
         CVarDef.Create("funkystation.reagent_fire.puddle_damage_multiplier", 1.0f, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Defines whether footprints are flammable.
+    /// </summary>
+    public static readonly CVarDef<bool> FootprintsFlammable =
+        CVarDef.Create("funkystation.reagent_fire.footprints_flammable", true, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Multiplier for effectiveness of fire protection from equipment.
+    /// </summary>
+    public static readonly CVarDef<float> FireProtectionEffectiveness =
+        CVarDef.Create("funkystation.reagent_fire.fire_protection_effectiveness", 1.0f, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Whether puddle volume scales down effective fire intensity for small amounts of liquid
+    /// </summary>
+    public static readonly CVarDef<bool> VolumeScalingEnabled =
+        CVarDef.Create("funkystation.reagent_fire.volume_scaling_enabled", true, CVar.SERVERONLY);
+
+    /// <summary>
+    /// The solution volume in units at which fire intensity is considered full strength. Puddles below this volume burn proportionally weaker
+    /// </summary>
+    public static readonly CVarDef<float> VolumeScalingReference =
+        CVarDef.Create("funkystation.reagent_fire.volume_scaling_reference", 20f, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Exponent applied to the volume ratio. Higher values punish small puddles harder. 1.0 is linear falloff.
+    /// </summary>
+    public static readonly CVarDef<float> VolumeScalingCurve =
+        CVarDef.Create("funkystation.reagent_fire.volume_scaling_curve", 1.5f, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Solution volume in units below which puddles burn out rapidly instead of following the normal rate
+    /// </summary>
+    public static readonly CVarDef<float> SmallPuddleBurnThreshold =
+        CVarDef.Create("funkystation.reagent_fire.small_puddle_burn_threshold", 5.0f, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Percentage of remaining volume consumed per second once a puddle is below the above threshold
+    /// </summary>
+    public static readonly CVarDef<float> SmallPuddleBurnPercent =
+        CVarDef.Create("funkystation.reagent_fire.small_puddle_burn_percent", 0.5f, CVar.SERVERONLY);
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
This PR adds new serverside CVars to make reagent fire behavior more tunable for the benefit of our downstreams, fixes a bug where the FireProtection component was never considered when dealing fire damage, and changes the behaviour of fire with regards to the volume of the puddle rather than just its flammability.

Reagent fire intensity now scales with the puddle's volume rather than being purely based on reagent flammability. A 0.1u footprint and a 50u puddle of the same reagent no longer burn identically.
<!-- What did you change? -->

## Why / Balance
Downstream feedback pointed out how reagents fires were *still* far too deadly in their server. Rather than nerfing reagent fires entirely, this PR allows each server to tune fires to their own tastes.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
New CVars in ReagentFireCVars.cs:
- footprints_flammable
- fire_protection_effectiveness
- volume_scaling_enabled
- volume_scaling_reference
- volume_scaling_curve
- small_puddle_burn_threshold
- small_puddle_burn_percent
<!-- Summary of code changes for easier review. -->

## Test plan
Ensure small puddles burn out significantly quicker than large ones, while being less intense overall.
Ensure footprints are no longer flammable when footprints_flammable is set to false.
Check out the different firesuits and make sure they now protect you much more effectively from fires.
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
https://github.com/user-attachments/assets/3877eaa7-84a0-48d9-8150-4f6afda2c6d9

<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->

## Changelog
:cl: AraiMaia
- tweak: Small puddles and footprints of flammable reagents now burn with reduced intensity and burn out much faster, instead of behaving identically to a large puddle of the same reagent.
- fix: Fire protection equipment now properly reduces damage from reagent fires.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
