### PR TITLE
Toastmed Part 1: Wounds!

### DIFF
--- a/Content.Client/Medical/Wounds/VisualOrganWoundsSystem.cs
+++ b/Content.Client/Medical/Wounds/VisualOrganWoundsSystem.cs
@@ -1,0 +1,68 @@
+// Baystation start
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Organs;
+using Content.Shared.Medical.Wounds;
+using Robust.Client.GameObjects;
+using Robust.Shared.Timing;
+
+namespace Content.Client.Medical.Wounds;
+
+/// <summary>
+///     Hides body sprite layers for limbs that have been cut away.
+/// </summary>
+public sealed partial class VisualOrganWoundsSystem : EntitySystem
+{
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private Robust.Client.Player.IPlayerManager _playerManager = default!;
+
+    private TimeSpan _nextUpdate;
+    private static readonly TimeSpan UpdateInterval = TimeSpan.FromSeconds(1);
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_timing.CurTime < _nextUpdate)
+            return;
+
+        _nextUpdate = _timing.CurTime + UpdateInterval;
+
+        var player = _playerManager.LocalEntity;
+        if (player == null)
+            return;
+
+        if (!TryComp<BodyComponent>(player.Value, out var body) || body.Organs == null)
+            return;
+
+        var spriteSys = EntityManager.System<SpriteSystem>();
+
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            if (TerminatingOrDeleted(organ))
+                continue;
+
+            if (!TryComp<ExternalOrganComponent>(organ, out var ext))
+                continue;
+
+            if (!TryComp<VisualOrganComponent>(organ, out var vis))
+                continue;
+
+            var layer = vis.Layer;
+            if (layer == null)
+                continue;
+
+            if ((ext.Status & OrganStatusFlags.CutAway) != 0)
+            {
+                if (spriteSys.LayerMapTryGet(player.Value, layer, out var baseIdx, false))
+                    spriteSys.LayerSetVisible(player.Value, baseIdx, false);
+            }
+            else
+            {
+                if (spriteSys.LayerMapTryGet(player.Value, layer, out var baseIdx, false))
+                    spriteSys.LayerSetVisible(player.Value, baseIdx, true);
+            }
+        }
+    }
+}
+// Baystation end

--- a/Content.Server/Commands/MedicalDebugCommand.cs
+++ b/Content.Server/Commands/MedicalDebugCommand.cs
@@ -1,0 +1,126 @@
+// Baystation start
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Organs;
+using Content.Shared.Medical.Wounds;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Commands;
+
+[AdminCommand(AdminFlags.Fun)]
+public sealed partial class MedicalDebugCommand : IConsoleCommand
+{
+    [Dependency] private IEntityManager _entMan = default!;
+    [Dependency] private IPrototypeManager _prototype = default!;
+
+    public string Command => "medicaldebug";
+    public string Description => "Prints medical debug info for a target entity.";
+    public string Help => "medicaldebug <entity uid>\nPrints limb damage, wounds, oxygenation, pulse, and brain status.";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length < 1)
+        {
+            shell.WriteLine("Usage: medicaldebug <entity uid>");
+            return;
+        }
+
+        if (!NetEntity.TryParse(args[0], out var nuid))
+        {
+            shell.WriteLine("Invalid entity UID.");
+            return;
+        }
+
+        var uid = _entMan.GetEntity(nuid);
+
+        shell.WriteLine($"=== Medical Debug: {_entMan.GetComponent<MetaDataComponent>(uid).EntityName} ({uid}) ===");
+
+        if (_entMan.TryGetComponent<BrainComponent>(uid, out var brain))
+        {
+            shell.WriteLine($"  Brain: {brain.Integrity}/{brain.MaxIntegrity} integrity, HasBeenDead={brain.HasBeenDead}");
+        }
+
+        if (_entMan.TryGetComponent<BloodOxygenationComponent>(uid, out var oxy))
+        {
+            shell.WriteLine($"  O2: {oxy.Oxygenation:P1}, Pulse: {oxy.PulseRate:F0} BPM, Arrest={oxy.CardiacArrest}, BasePulse={oxy.BasePulse}");
+        }
+
+        if (_entMan.TryGetComponent<BloodTypeComponent>(uid, out var bloodType))
+        {
+            shell.WriteLine($"  Blood: {bloodType.DisplayString}");
+        }
+
+        if (_entMan.TryGetComponent<BloodstreamComponent>(uid, out var stream))
+        {
+            shell.WriteLine($"  BleedAmount: {stream.BleedAmount:F2}, MaxBleed: {stream.MaxBleedAmount}");
+        }
+
+        if (_entMan.TryGetComponent<BodyComponent>(uid, out var body) && body.Organs != null)
+        {
+            foreach (var organ in body.Organs.ContainedEntities)
+            {
+                var organName = _entMan.GetComponent<MetaDataComponent>(organ).EntityName;
+
+                if (_entMan.TryGetComponent<ExternalOrganComponent>(organ, out var ext))
+                {
+                    var limbInfo = $"  Limb [{organName}]: Brute={ext.BruteDamage}, Burn={ext.BurnDamage}, Stage={ext.SurgeryStage}, Status={ext.Status}";
+                    if (ext.Dislocated)
+                        limbInfo += ", DISLOCATED";
+                    shell.WriteLine(limbInfo);
+                }
+
+                if (_entMan.TryGetComponent<WoundableComponent>(organ, out var woundable))
+                {
+                    shell.WriteLine($"    Wounds: {woundable.Wounds.Count}, TotalDmg={woundable.TotalDamage.GetTotal()}");
+
+                    foreach (var woundUid in woundable.Wounds)
+                    {
+                        if (!_entMan.TryGetComponent<WoundComponent>(woundUid, out var wound))
+                        {
+                            shell.WriteLine($"      [INVALID WOUND]");
+                            continue;
+                        }
+
+                        var wName = _entMan.GetComponent<MetaDataComponent>(woundUid).EntityName;
+                        var wDmg = wound.Damage.GetTotal();
+                        var woundInfo = $"      Wound [{wName}]: dmg={wDmg}, max={wound.MaximumDamage}, stage={wound.Stage}/{wound.MaxStages}, heal={wound.HealPerTick}, surgical={wound.IsSurgical}";
+
+                        if (_entMan.TryGetComponent<WoundEffectsComponent>(woundUid, out var effects))
+                        {
+                            foreach (var instance in effects.Effects)
+                            {
+                                var proto = _prototype.Index(instance.Id);
+                                woundInfo += $" | {proto.EffectType}";
+
+                                if (instance.FloatParams.Count > 0)
+                                {
+                                    foreach (var kvp in instance.FloatParams)
+                                        woundInfo += $" {kvp.Key}={kvp.Value:F1}";
+                                }
+
+                                if (instance.StringListParams.Count > 0)
+                                    woundInfo += $" items=[{string.Join(",", instance.StringListParams)}]";
+                            }
+                        }
+
+                        shell.WriteLine(woundInfo);
+                    }
+                }
+
+                if (_entMan.TryGetComponent<HeartConditionComponent>(organ, out var heart))
+                    shell.WriteLine($"  Organ [{organName}]: Heart beating={heart.Beating}, eff={heart.Efficiency:P0}");
+
+                if (_entMan.TryGetComponent<LungConditionComponent>(organ, out var lung))
+                    shell.WriteLine($"  Organ [{organName}]: Lung eff={lung.Efficiency:P0}");
+            }
+        }
+        else
+        {
+            shell.WriteLine("  No body component or no organs found.");
+        }
+    }
+}
+// Baystation end

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -1,5 +1,7 @@
 using Content.Server.Medical.Components;
+using Content.Shared.Body;
 using Content.Shared.Body.Components;
+using Content.Shared.Body.Organs;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Damage.Components;
 using Content.Shared.DoAfter;
@@ -248,13 +250,94 @@ public sealed partial class HealthAnalyzerSystem : EntitySystem
         if (TryComp<UnrevivableComponent>(entity, out var unrevivableComp) && unrevivableComp.Analyzable)
             unrevivable = true;
 
-        return new HealthAnalyzerUiState(
+// Baystation start
+        var brainActivity = "Normal";
+        var pulseRate = 0f;
+        var bloodOxygenation = 0f;
+        var limbs = new List<LimbScanData>();
+        var reagents = new List<ReagentScanData>();
+        var hasFractures = false;
+        var hasInternalBleeding = false;
+        var hasOrganFailure = false;
+
+        // Brain activity
+        if (TryComp<BodyComponent>(entity, out var body) && body.Organs != null)
+        {
+            foreach (var organ in body.Organs.ContainedEntities)
+            {
+                if (TryComp<BrainComponent>(organ, out var brain))
+                {
+                    var pct = (float)(brain.Integrity / brain.MaxIntegrity).Float();
+                    brainActivity = pct <= 0 ? "None" : pct < 0.5f ? "Fading" : "Normal";
+                }
+
+                // Per-limb damage
+                if (TryComp<ExternalOrganComponent>(organ, out var ext))
+                {
+                    var name = EntityManager.GetComponent<MetaDataComponent>(organ).EntityName;
+                    limbs.Add(new LimbScanData
+                    {
+                        Name = name,
+                        BruteDamage = ext.BruteDamage,
+                        BurnDamage = ext.BurnDamage,
+                        Fractured = (ext.Status & OrganStatusFlags.Broken) != 0,
+                        Bleeding = (ext.Status & OrganStatusFlags.Bleeding) != 0
+                    });
+
+                    if ((ext.Status & OrganStatusFlags.Broken) != 0)
+                        hasFractures = true;
+
+                    if ((ext.Status & OrganStatusFlags.ArteryCut) != 0)
+                        hasInternalBleeding = true;
+                }
+
+                // Heart condition
+                if (TryComp<HeartConditionComponent>(organ, out var heart))
+                {
+                    if (!heart.Beating)
+                        hasOrganFailure = true;
+                }
+            }
+        }
+
+        // Pulse and oxygenation
+        if (TryComp<BloodOxygenationComponent>(entity, out var oxy))
+        {
+            pulseRate = oxy.PulseRate;
+            bloodOxygenation = oxy.Oxygenation * 100f;
+        }
+
+        // Reagent scan from bloodstream
+        if (TryComp<BloodstreamComponent>(entity, out var bs))
+        {
+            if (_solutionContainerSystem.ResolveSolution(entity, bs.BloodSolutionName, ref bs.BloodSolution, out var bSol))
+            {
+                foreach (var (reagent, quantity) in bSol.Contents)
+                {
+                    if (reagent.Prototype is { } reagentId && quantity > 0)
+                        reagents.Add(new ReagentScanData { Name = reagentId, Quantity = quantity });
+                }
+            }
+        }
+
+        var state = new HealthAnalyzerUiState(
             GetNetEntity(entity),
             bodyTemperature,
             bloodAmount,
             null,
             bleeding,
-            unrevivable
-        );
+            unrevivable)
+        {
+            BrainActivity = brainActivity,
+            PulseRate = pulseRate,
+            BloodOxygenation = bloodOxygenation,
+            Limbs = limbs,
+            Reagents = reagents,
+            HasFractures = hasFractures,
+            HasInternalBleeding = hasInternalBleeding,
+            HasOrganFailure = hasOrganFailure
+        };
+
+        return state;
     }
 }

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -274,7 +274,7 @@ public sealed partial class HealthAnalyzerSystem : EntitySystem
                 // Per-limb damage
                 if (TryComp<ExternalOrganComponent>(organ, out var ext))
                 {
-                    var name = EntityManager.GetComponent<MetaDataComponent>(organ).EntityName;
+                    var name = Comp<MetaDataComponent>(organ).EntityName;
                     limbs.Add(new LimbScanData
                     {
                         Name = name,

--- a/Content.Server/Medical/Sterilizine/SterilizineSystem.cs
+++ b/Content.Server/Medical/Sterilizine/SterilizineSystem.cs
@@ -1,0 +1,66 @@
+// Baystation start
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Interaction;
+using Content.Shared.Medical.Sterilizine;
+using Content.Shared.Medical.Wounds;
+using Content.Shared.Popups;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Medical.Sterilizine;
+
+public sealed partial class SterilizineSystem : EntitySystem
+{
+    [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private IPrototypeManager _prototype = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SterilizineComponent, AfterInteractEvent>(OnAfterInteract);
+    }
+
+    private void OnAfterInteract(Entity<SterilizineComponent> ent, ref AfterInteractEvent args)
+    {
+        if (args.Handled || args.Target == null || !args.CanReach)
+            return;
+
+        if (!TryComp<BodyComponent>(args.Target.Value, out var body) || body.Organs == null)
+            return;
+
+        args.Handled = true;
+        var cleaned = 0;
+
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            if (!TryComp<WoundableComponent>(organ, out var woundable))
+                continue;
+
+            foreach (var woundUid in woundable.Wounds)
+            {
+                if (TerminatingOrDeleted(woundUid))
+                    continue;
+
+                if (!TryComp<WoundEffectsComponent>(woundUid, out var effects))
+                    continue;
+
+                var germInstance = effects.GetEffect("Germ", _prototype);
+                if (germInstance == null)
+                    continue;
+
+                var newLevel = Math.Max(0, germInstance.GetFloat("germLevel") - 10);
+                germInstance.SetFloat("germLevel", newLevel);
+                germInstance.SetFloat("disinfected", 1);
+                Dirty(woundUid, effects);
+                cleaned++;
+            }
+        }
+
+        if (cleaned > 0)
+            _popup.PopupEntity(Loc.GetString("sterilizine-applied", ("count", cleaned)), args.Target.Value, args.User, PopupType.Medium);
+        else
+            _popup.PopupEntity(Loc.GetString("sterilizine-no-effect"), args.Target.Value, args.User);
+    }
+}
+// Baystation end

--- a/Content.Server/Medical/Wounds/InfectionSystem.cs
+++ b/Content.Server/Medical/Wounds/InfectionSystem.cs
@@ -1,0 +1,113 @@
+// Baystation start
+using Content.Shared.Body;
+using Content.Shared.Body.Organs;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Systems;
+using Content.Shared.FixedPoint;
+using Content.Shared.Medical.Wounds;
+using Content.Shared.Popups;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server.Medical.Wounds;
+
+public sealed partial class InfectionSystem : EntitySystem
+{
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private DamageableSystem _damageable = default!;
+    [Dependency] private IPrototypeManager _prototype = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private IRobustRandom _random = default!;
+
+    private TimeSpan _nextUpdate;
+    public TimeSpan UpdateInterval = TimeSpan.FromSeconds(3);
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var curTime = _timing.CurTime;
+        if (curTime < _nextUpdate)
+            return;
+
+        _nextUpdate = curTime + UpdateInterval;
+
+        var query = EntityQueryEnumerator<WoundComponent>();
+        while (query.MoveNext(out var uid, out var wound))
+        {
+            if (!TryComp<WoundEffectsComponent>(uid, out var effects))
+                continue;
+
+            var germInstance = effects.GetEffect("Germ", _prototype);
+            if (germInstance == null)
+                continue;
+
+// Baystation: disinfected wounds are immune to infection
+            var disinfected = germInstance.GetFloat("disinfected") > 0;
+            if (disinfected)
+                continue;
+
+            var tended = effects.GetEffect("Tendable", _prototype) is { } tend
+                && tend.GetFloat("tended") > 0;
+            var salved = effects.GetEffect("Salvable", _prototype) is { } salve
+                && salve.GetFloat("salved") > 0;
+
+            if (!tended && !salved)
+            {
+// Baystation probabilistic infection
+                var totalDmg = wound.Damage.GetTotal().Float();
+                if (totalDmg >= 10)
+                {
+                    var infectionChance = wound.Group.ToLowerInvariant() switch
+                    {
+                        "burn" => totalDmg / 10f * 25f,
+                        "cut" => totalDmg / 10f * 10f,
+                        "puncture" => totalDmg / 10f * 10f,
+                        "brute" => totalDmg / 10f * 5f,
+                        _ => totalDmg / 10f * 10f
+                    };
+
+                    infectionChance = Math.Min(infectionChance, 95f);
+
+                    if (_random.Prob(infectionChance / 100f))
+                        germInstance.SetFloat("germLevel", germInstance.GetFloat("germLevel") + 1);
+                }
+            }
+            else
+            {
+                // Treated wounds lose germs over time
+                germInstance.SetFloat("germLevel", Math.Max(0, germInstance.GetFloat("germLevel") - 1));
+            }
+
+            var germLevel = Math.Clamp(germInstance.GetFloat("germLevel"), 0, 100);
+            germInstance.SetFloat("germLevel", germLevel);
+
+            if (germLevel <= 0)
+                continue;
+
+            if (germLevel > 20 && wound.ParentWoundable is { } parent)
+            {
+                var damage = new DamageSpecifier();
+                damage.DamageDict.Add("Poison", FixedPoint2.New(germLevel * 0.05f));
+                _damageable.TryChangeDamage(parent, damage, interruptsDoAfters: false);
+
+                // Necrotic organ: germ level > 80 causes necrosis
+                if (germLevel > 80 && TryComp<ExternalOrganComponent>(parent, out var ext)
+                    && (ext.Status & OrganStatusFlags.Dead) == 0
+                    && (ext.Status & OrganStatusFlags.Robotic) == 0)
+                {
+                    ext.Status |= OrganStatusFlags.Dead;
+                    Dirty(parent, ext);
+                    var msg = Loc.GetString("limb-necrotic", ("limb", Name(parent)));
+                    // Send popup to the body owner
+                    if (TryComp<OrganComponent>(parent, out var org) && org.Body is { } bodyEnt)
+                        _popup.PopupEntity(msg, parent, bodyEnt, PopupType.Medium);
+                }
+            }
+
+            Dirty(uid, effects);
+        }
+    }
+}
+// Baystation end

--- a/Content.Server/Medical/Wounds/WoundRegenerationSystem.cs
+++ b/Content.Server/Medical/Wounds/WoundRegenerationSystem.cs
@@ -1,0 +1,128 @@
+// Baystation start
+using Content.Shared.FixedPoint;
+using Content.Shared.Medical.Wounds;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Server.Medical.Wounds;
+
+public sealed partial class WoundRegenerationSystem : EntitySystem
+{
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IPrototypeManager _prototype = default!;
+
+    private TimeSpan _nextUpdate;
+    public TimeSpan UpdateInterval = TimeSpan.FromSeconds(2);
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var curTime = _timing.CurTime;
+        if (curTime < _nextUpdate)
+            return;
+
+        _nextUpdate = curTime + UpdateInterval;
+
+        var query = EntityQueryEnumerator<WoundComponent>();
+        while (query.MoveNext(out var uid, out var wound))
+        {
+            if (wound.IsSurgical)
+                continue;
+
+            if (!TryComp<WoundEffectsComponent>(uid, out var effects))
+                continue;
+
+            // Embedded objects prevent natural healing
+            var embedded = effects.GetEffect("Embedded", _prototype);
+            if (embedded is { StringListParams: { Count: > 0 } })
+                continue;
+
+            var healable = effects.GetEffect("Healable", _prototype);
+            if (healable == null)
+                continue;
+
+            var healPerTick = healable.GetFloatOrConfig("healPerTick", _prototype);
+            if (healPerTick <= 0)
+                continue;
+
+            var totalDamage = wound.Damage.GetTotal();
+            if (totalDamage <= 0)
+            {
+                RemoveWound(uid, wound);
+                continue;
+            }
+
+// Baystation-style autoheal cutoff: wounds above this damage don't heal unless treated
+            var autohealCutoff = healable.GetFloatOrConfig("autohealCutoff", _prototype);
+            var currentDmg = (float)totalDamage.Float();
+            if (autohealCutoff > 0 && currentDmg > autohealCutoff)
+            {
+                // Check if the wound is treated (tended for cuts/pierce, salved for burns)
+                var treated = effects.GetEffect("Tendable", _prototype) is { } tend
+                    && tend.GetFloat("tended") > 0;
+                if (!treated && effects.GetEffect("Salvable", _prototype) is { } salveEff)
+                    treated = salveEff.GetFloat("salved") > 0;
+                if (!treated)
+                    continue;
+            }
+
+            // Tended wounds heal twice as fast
+            var tended = effects.GetEffect("Tendable", _prototype) is { } tendEff
+                && tendEff.GetFloat("tended") > 0;
+            var healRate = healPerTick * (tended ? 2 : 1);
+
+            var raw = (float)totalDamage.Float();
+            foreach (var (type, value) in wound.Damage.DamageDict)
+            {
+                if (value > 0)
+                {
+                    var reduction = FixedPoint2.New((float)value.Float() * (healRate / raw));
+                    wound.Damage.DamageDict[type] = value - reduction;
+                }
+            }
+
+            // Decrement bleed timer (Baystation: wounds naturally stop bleeding over time)
+            var bleedInstance = effects.GetEffect("Bleeding", _prototype);
+            if (bleedInstance != null)
+            {
+                var bleedTimer = bleedInstance.GetFloat("bleedTimer");
+                if (bleedTimer > 0)
+                {
+                    bleedTimer -= 1;
+                    if (bleedTimer < 0)
+                        bleedTimer = 0;
+                    bleedInstance.SetFloat("bleedTimer", bleedTimer);
+                }
+            }
+
+            var maxDmg = (float)wound.MaximumDamage.Float();
+            var curDmg = (float)wound.Damage.GetTotal().Float();
+            var pct = maxDmg > 0 ? curDmg / maxDmg : 0;
+
+            wound.Stage = pct switch
+            {
+                > 0.80f => 0,
+                > 0.60f => 1,
+                > 0.40f => 2,
+                > 0.20f => 3,
+                > 0f   => 4,
+                _      => wound.MaxStages - 1
+            };
+
+            Dirty(uid, wound);
+        }
+    }
+
+    private void RemoveWound(EntityUid uid, WoundComponent wound)
+    {
+        QueueDel(uid);
+
+        if (wound.ParentWoundable is { } parent && TryComp<WoundableComponent>(parent, out var wc))
+        {
+            wc.Wounds.Remove(uid);
+            Dirty(parent, wc);
+        }
+    }
+}
+// Baystation end

--- a/Content.Shared/Body/BodyComponent.cs
+++ b/Content.Shared/Body/BodyComponent.cs
@@ -13,6 +13,7 @@ namespace Content.Shared.Body;
 public sealed partial class BodyComponent : Component
 {
     public const string ContainerID = "body_organs";
+    public const string WoundContainerID = "body_wounds";
 
     /// <summary>
     /// The actual container with entities with <see cref="OrganComponent" /> in it

--- a/Content.Shared/Body/BodyComponent.cs
+++ b/Content.Shared/Body/BodyComponent.cs
@@ -13,7 +13,6 @@ namespace Content.Shared.Body;
 public sealed partial class BodyComponent : Component
 {
     public const string ContainerID = "body_organs";
-    public const string WoundContainerID = "body_wounds";
 
     /// <summary>
     /// The actual container with entities with <see cref="OrganComponent" /> in it

--- a/Content.Shared/Body/Components/BloodOxygenationComponent.cs
+++ b/Content.Shared/Body/Components/BloodOxygenationComponent.cs
@@ -1,0 +1,31 @@
+// Baystation start
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared.Body.Components;
+
+[RegisterComponent, AutoGenerateComponentState]
+public sealed partial class BloodOxygenationComponent : Component
+{
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
+    public TimeSpan NextUpdate;
+
+    [DataField, AutoNetworkedField]
+    public float Oxygenation = 1.0f;
+
+    [DataField, AutoNetworkedField]
+    public int PulseLevel = 2;
+
+    [DataField, AutoNetworkedField]
+    public float PulseRate = 72f;
+
+    [DataField, AutoNetworkedField]
+    public bool CardiacArrest;
+
+    [DataField, AutoNetworkedField]
+    public float BasePulse = 72f;
+
+    [DataField, AutoNetworkedField]
+    public float AccumulatedBrainDamage;
+}
+// Baystation end

--- a/Content.Shared/Body/Components/BloodTypeComponent.cs
+++ b/Content.Shared/Body/Components/BloodTypeComponent.cs
@@ -1,0 +1,90 @@
+// Baystation start
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Body.Components;
+
+/// <summary>
+/// Defines the blood type of an entity and provides compatibility checking for cross reactions.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class BloodTypeComponent : Component
+{
+    /// <summary>
+    /// The blood type group (A, B, AB, O).
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public BloodGroup Group = BloodGroup.O;
+
+    /// <summary>
+    /// Whether the Rh factor is positive.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool RhPositive = true;
+
+    /// <summary>
+    /// Returns a string representation (e.g., "A+", "O-").
+    /// </summary>
+    public string DisplayString => $"{Group}{(RhPositive ? "+" : "-")}";
+
+    /// <summary>
+    /// Checks if this blood type is compatible with a donor blood type (recipient is this, donor is the argument).
+    /// O- is universal donor. AB+ is universal recipient.
+    /// </summary>
+    public bool IsCompatibleWith(BloodGroup donorGroup, bool donorRhPositive)
+    {
+        // AB can receive from anyone
+        if (Group == BloodGroup.AB)
+        {
+            // Rh- can receive Rh- only, Rh+ can receive both
+            if (!RhPositive && donorRhPositive)
+                return false;
+            return true;
+        }
+
+        // A can receive from A and O
+        if (Group == BloodGroup.A)
+        {
+            if (donorGroup != BloodGroup.A && donorGroup != BloodGroup.O)
+                return false;
+            if (!RhPositive && donorRhPositive)
+                return false;
+            return true;
+        }
+
+        // B can receive from B and O
+        if (Group == BloodGroup.B)
+        {
+            if (donorGroup != BloodGroup.B && donorGroup != BloodGroup.O)
+                return false;
+            if (!RhPositive && donorRhPositive)
+                return false;
+            return true;
+        }
+
+        // O can receive from O only
+        if (Group == BloodGroup.O)
+        {
+            if (donorGroup != BloodGroup.O)
+                return false;
+            if (!RhPositive && donorRhPositive)
+                return false;
+            return true;
+        }
+
+        return false;
+    }
+}
+
+/// <summary>
+/// Blood group enum.
+/// </summary>
+[Serializable, NetSerializable]
+public enum BloodGroup : byte
+{
+    A,
+    B,
+    AB,
+    O
+}
+// Baystation end

--- a/Content.Shared/Body/Components/BrainComponent.cs
+++ b/Content.Shared/Body/Components/BrainComponent.cs
@@ -1,6 +1,42 @@
+// Baystation start
 using Content.Shared.Body.Systems;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared.Body.Components;
 
-[RegisterComponent, Access(typeof(BrainSystem))]
-public sealed partial class BrainComponent : Component;
+/// <summary>
+/// Tracks brain integrity (0-100%).
+/// When brain integrity reaches 0%, the entity is considered brain-dead.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(BrainSystem), Other = AccessPermissions.Read)]
+public sealed partial class BrainComponent : Component
+{
+    /// <summary>
+    /// Current brain integrity, ranging from 0 to MaxIntegrity.
+    /// 0 = brain dead, MaxIntegrity = perfectly healthy.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Integrity = FixedPoint2.New(100);
+
+    /// <summary>
+    /// Maximum possible brain integrity.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 MaxIntegrity = FixedPoint2.New(100);
+
+    /// <summary>
+    /// Minimum integrity before brain death occurs.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 MinDeadIntegrity;
+
+    /// <summary>
+    /// Whether this brain has ever reached 0 integrity.
+    /// Used to determine if cloning is possible.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool HasBeenDead;
+}
+// Baystation end

--- a/Content.Shared/Body/Components/HeartConditionComponent.cs
+++ b/Content.Shared/Body/Components/HeartConditionComponent.cs
@@ -1,0 +1,25 @@
+// Baystation start
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Body.Components;
+
+/// <summary>
+/// Tracks heart condition. Efficiency 0-1 determines how well the heart pumps blood.
+/// 1.0 = healthy, 0.0 = total failure (cardiac arrest).
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class HeartConditionComponent : Component
+{
+    /// <summary>
+    /// How efficiently the heart pumps blood (0.0 to 1.0).
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Efficiency = 1.0f;
+
+    /// <summary>
+    /// Whether the heart is currently beating. False means cardiac arrest.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Beating = true;
+}
+// Baystation end

--- a/Content.Shared/Body/Components/LungConditionComponent.cs
+++ b/Content.Shared/Body/Components/LungConditionComponent.cs
@@ -1,0 +1,19 @@
+// Baystation start
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Body.Components;
+
+/// <summary>
+/// Tracks lung condition. Efficiency 0-1 determines how well the lungs oxygenate blood.
+/// 1.0 = healthy, 0.0 = total failure.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class LungConditionComponent : Component
+{
+    /// <summary>
+    /// How efficiently the lungs oxygenate blood.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Efficiency = 1.0f;
+}
+// Baystation end

--- a/Content.Shared/Body/Events/LimbEvents.cs
+++ b/Content.Shared/Body/Events/LimbEvents.cs
@@ -1,0 +1,48 @@
+// Baystation start
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Organs;
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared.Body.Events;
+
+/// <summary>
+///     The type of limb dismemberment.
+/// </summary>
+public enum DropLimbType : byte
+{
+    Edge,  // Cut clean off (sharp weapon)
+    Blunt, // Shattered off (explosion)
+    Burn,  // Burned away (extreme heat)
+}
+
+/// <summary>
+///     Raised when a limb is fractured.
+/// </summary>
+[ByRefEvent]
+public readonly record struct LimbFracturedEvent(Entity<ExternalOrganComponent> Limb);
+
+/// <summary>
+///     Raised when a limb is dismembered.
+/// </summary>
+[ByRefEvent]
+public readonly record struct LimbDismemberedEvent(EntityUid Body, Entity<ExternalOrganComponent> Limb, DropLimbType Type);
+
+/// <summary>
+///     Raised to check if a limb should be fractured due to brute damage.
+///     Handled by the server-side ExternalOrganSystem.
+/// </summary>
+[ByRefEvent]
+public readonly record struct LimbFractureCheckEvent(Entity<ExternalOrganComponent> Limb, FixedPoint2 Damage);
+
+/// <summary>
+///     Raised to amputate a limb. Handled by the server-side ExternalOrganSystem.
+/// </summary>
+[ByRefEvent]
+public readonly record struct LimbAmputateEvent(Entity<ExternalOrganComponent> Limb, DropLimbType Type);
+
+/// <summary>
+///     Raised when an entity's brain has died (integrity reached 0).
+/// </summary>
+[ByRefEvent]
+public readonly record struct BrainDeathEvent(EntityUid Body, Entity<BrainComponent> Brain);
+// Baystation end

--- a/Content.Shared/Body/Organs/ExternalOrganComponent.cs
+++ b/Content.Shared/Body/Organs/ExternalOrganComponent.cs
@@ -1,0 +1,126 @@
+// Baystation start
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Body.Organs;
+
+/// <summary>
+///Baystation-style external organ (limb) component.
+///Tracks per-limb brute/burn damage, status flags, and surgery state.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ExternalOrganComponent : Component
+{
+    /// <summary>
+    /// Total brute damage on this limb (Blunt + Slash + Piercing).
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 BruteDamage;
+
+    /// <summary>
+    /// Total burn damage on this limb (Heat + Cold + Shock + Caustic).
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 BurnDamage;
+
+    /// <summary>
+    /// Maximum damage this limb can sustain before being considered destroyed/dead.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 MaxDamage = 100;
+
+    /// <summary>
+    /// Damage threshold above which this limb becomes broken (fractured).
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 MinBrokenDamage = 60;
+
+    /// <summary>
+    /// Organ status flags
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public OrganStatusFlags Status;
+
+    /// <summary>
+    /// Limb capability flags
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public LimbFlags Flags;
+
+    /// <summary>
+    /// Whether this limb is dislocated.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Dislocated;
+
+    /// <summary>
+    /// Surgery state: tracks incision/clamping/retraction/encasement progress.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public SurgeryStage SurgeryStage;
+
+    /// <summary>
+    /// Bone repair progress (0=none, 1=glued, 2=set, 3=finished).
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int BoneRepairStage;
+
+    /// <summary>
+    /// Name of the encased bone structure (e.g. "ribcage", "skull").
+    /// If set, this limb requires sawing through bone to access internals.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string? Encased;
+
+    /// <summary>
+    /// Whether this limb is disfigured (not implemented yet, might just be a simple text added to the examine... idk)
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Disfigured;
+}
+
+/// <summary>
+/// Organ/limb status.
+/// </summary>
+[Flags, Serializable, NetSerializable]
+public enum OrganStatusFlags : byte
+{
+    None = 0,
+    Broken = 1 << 0,       // Bone is fractured
+    Bleeding = 1 << 1,     // Limb is bleeding (open wound)
+    Dead = 1 << 2,         // Limb tissue is necrotic/dead
+    CutAway = 1 << 3,      // Limb has been surgically opened
+    ArteryCut = 1 << 4,    // Artery has been severed
+    TendonCut = 1 << 5,    // Tendon has been severed
+    Robotic = 1 << 6,      // Limb is robotic/prosthetic
+    Brittle = 1 << 7,      // Robotic limb is brittle
+}
+
+/// <summary>
+/// Bitfield flags for limb capabilities.
+/// </summary>
+[Flags, Serializable, NetSerializable]
+public enum LimbFlags : byte
+{
+    None = 0,
+    CanAmputate = 1 << 0,  // Can be amputated
+    CanBreak = 1 << 1,     // Can be fractured
+    CanGrasp = 1 << 2,     // Can grasp items (hands)
+    CanStand = 1 << 3,     // Can support standing (legs)
+    HasTendon = 1 << 4,    // Has tendons that can be severed
+}
+
+/// <summary>
+/// Surgery stage for an external organ.
+/// </summary>
+[Serializable, NetSerializable]
+public enum SurgeryStage : byte
+{
+    None,
+    Incised,    // Skin cut open (scalpel used)
+    Clamped,    // Bleeders clamped (hemostat used)
+    Retracted,  // Skin retracted (retractors used)
+    Encased,    // Bone/ribcage opened (saw used)
+}
+// Baystation end

--- a/Content.Shared/Body/Systems/BloodOxygenationSystem.cs
+++ b/Content.Shared/Body/Systems/BloodOxygenationSystem.cs
@@ -1,0 +1,442 @@
+// Baystation start
+using Content.Shared.Body.Components;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Systems;
+using Content.Shared.FixedPoint;
+using Content.Shared.Medical.CPR;
+using Content.Shared.Medical.Pain;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+using Robust.Shared.Network;
+
+namespace Content.Shared.Body.Systems;
+
+/// <summary>
+/// Baystation-style blood oxygenation and pulse system.
+/// Pulse uses discrete levels (0-5) with probabilistic heart damage and cardiac arrest.
+/// </summary>
+public sealed partial class BloodOxygenationSystem : EntitySystem
+{
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private SharedSolutionContainerSystem _solution = default!;
+    [Dependency] private DamageableSystem _damageable = default!;
+    [Dependency] private MobStateSystem _mobState = default!;
+    [Dependency] private MobThresholdSystem _mobThreshold = default!;
+    [Dependency] private BrainSystem _brain = default!;
+    [Dependency] private INetManager _net = default!;
+
+// Baystation pulse levels (PULSE_NONE=0 through PULSE_THREADY=5)
+    public const int PULSE_NONE = 0;     // cardiac arrest
+    public const int PULSE_SLOW = 1;     // ~50 BPM
+    public const int PULSE_NORM = 2;     // ~72 BPM (normal)
+    public const int PULSE_FAST = 3;     // ~100 BPM
+    public const int PULSE_2FAST = 4;    // ~150 BPM (1%/tick heart damage)
+    public const int PULSE_THREADY = 5;  // ~200+ BPM (5%/tick heart damage, 5%/tick cardiac arrest)
+
+    public const float O2_THRESHOLD_BRAIN_DAMAGE = 0.85f;
+    public const float O2_THRESHOLD_LETHAL = 0.30f;
+    public const float DEXALIN_BONUS = 0.50f;
+    public const float DEXALIN_PLUS_BONUS = 0.80f;
+
+    /// <summary>
+    /// How often the oxygenation system updates (every 2 seconds = 1 tick at default 20TPS).
+    /// </summary>
+    public TimeSpan UpdateInterval = TimeSpan.FromSeconds(2);
+
+    private const string Dexalin = "Dexalin";
+    private const string DexalinPlus = "DexalinPlus";
+
+    private HashSet<EntityUid> _toProcess = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BloodOxygenationComponent, MapInitEvent>(OnMapInit);
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (!_net.IsServer)
+            return;
+
+        base.Update(frameTime);
+
+        var curTime = _timing.CurTime;
+        var query = EntityQueryEnumerator<BloodOxygenationComponent>();
+        while (query.MoveNext(out var uid, out var oxygenation))
+        {
+            if (curTime < oxygenation.NextUpdate)
+                continue;
+
+            oxygenation.NextUpdate = curTime + UpdateInterval;
+            ProcessOxygenation(uid, oxygenation);
+        }
+    }
+
+    private void OnMapInit(Entity<BloodOxygenationComponent> ent, ref MapInitEvent args)
+    {
+        ent.Comp.NextUpdate = _timing.CurTime + UpdateInterval;
+        ent.Comp.Oxygenation = 1.0f;
+        ent.Comp.PulseLevel = PULSE_NORM;
+        ent.Comp.PulseRate = PulseLevelToBPM(PULSE_NORM);
+        ent.Comp.CardiacArrest = false;
+    }
+
+    private void ProcessOxygenation(EntityUid uid, BloodOxygenationComponent oxygenation)
+    {
+        if (_mobState.IsDead(uid))
+            return;
+
+        if (oxygenation.CardiacArrest)
+        {
+            if (TryComp<CPRComponent>(uid, out var cpr) && cpr.Active)
+            {
+                var cprOutput = cpr.CardiacOutputModifier;
+                var cprBloodVolume = GetBloodVolumeRatio(uid);
+                var cprLungEff = GetLungEfficiency(uid);
+                oxygenation.Oxygenation = cprBloodVolume * cprLungEff * cprOutput + GetDexalinBonus(uid);
+                oxygenation.Oxygenation = Math.Clamp(oxygenation.Oxygenation, 0, 1);
+                oxygenation.PulseLevel = PULSE_SLOW;
+                oxygenation.PulseRate = PulseLevelToBPM(PULSE_SLOW);
+                ApplyOxygenEffects(uid, oxygenation);
+            }
+            else
+            {
+                oxygenation.Oxygenation = Math.Max(0, oxygenation.Oxygenation - 0.05f);
+                oxygenation.PulseLevel = PULSE_NONE;
+                oxygenation.PulseRate = 0;
+                ApplyOxygenEffects(uid, oxygenation);
+            }
+            return;
+        }
+
+        var bloodVolume = GetBloodVolumeRatio(uid);
+        var lungEff = GetLungEfficiency(uid);
+        var heartEff = GetHeartEfficiency(uid);
+        var dexalinBonus = GetDexalinBonus(uid);
+
+        oxygenation.Oxygenation = bloodVolume * lungEff * heartEff + dexalinBonus;
+        oxygenation.Oxygenation = Math.Clamp(oxygenation.Oxygenation, 0, 1);
+
+// Baystation pulse level calculation
+        oxygenation.PulseLevel = CalculatePulseLevel(uid, oxygenation);
+
+        // Apply probabilistic heart damage at high pulse (Baystation model)
+        if (oxygenation.PulseLevel >= PULSE_2FAST)
+        {
+            // PULSE_2FAST: 1% chance/tick of heart damage
+            if (oxygenation.PulseLevel == PULSE_2FAST && _random.Prob(0.01f))
+                DamageHeart(uid);
+
+            // PULSE_THREADY: 5% chance/tick of heart damage
+            if (oxygenation.PulseLevel == PULSE_THREADY && _random.Prob(0.05f))
+                DamageHeart(uid);
+
+            // PULSE_THREADY: 5% chance/tick of cardiac arrest
+            if (oxygenation.PulseLevel == PULSE_THREADY && _random.Prob(0.05f))
+            {
+                SetCardiacArrest(uid, oxygenation, true);
+                return;
+            }
+        }
+
+        // Convert pulse level to display BPM
+        oxygenation.PulseRate = PulseLevelToBPM(oxygenation.PulseLevel);
+
+        ApplyOxygenEffects(uid, oxygenation);
+    }
+
+    /// <summary>
+    /// Computes pulse level (0-5)
+    /// Base = PULSE_NORM (2).
+    /// +1 from low O2, +1/2 from shock, chemicals can modify.
+    /// Inaprovaline (CE_STABLE) pulls toward PULSE_NORM.
+    /// </summary>
+    private int CalculatePulseLevel(EntityUid uid, BloodOxygenationComponent oxy)
+    {
+        // Start at normal
+        var pulseMod = 0;
+
+        // Shock contribution
+        if (TryComp<PainComponent>(uid, out var pain))
+        {
+            if (pain.ShockLevel > 80)
+                pulseMod += 2;
+            else if (pain.ShockLevel > 30)
+                pulseMod += 1;
+        }
+
+        // Low O2 contribution
+        if (oxy.Oxygenation < 0.60f)
+            pulseMod += 2;
+        else if (oxy.Oxygenation < 0.70f)
+            pulseMod += 1;
+
+        // Clamp to valid range
+        var pulseLevel = Math.Clamp(PULSE_NORM + pulseMod, PULSE_SLOW, PULSE_THREADY);
+
+        // Inaprovaline stabilization: pull toward PULSE_NORM
+        if (HasInaprovaline(uid) && pulseLevel != PULSE_NORM)
+        {
+            if (pulseLevel > PULSE_NORM)
+                pulseLevel--;
+            else
+                pulseLevel++;
+        }
+
+        return pulseLevel;
+    }
+
+    /// <summary>
+    /// converts pulse level to approximate BPM for display.
+    /// </summary>
+    private static float PulseLevelToBPM(int level)
+    {
+        return level switch
+        {
+            PULSE_NONE => 0,
+            PULSE_SLOW => 50,
+            PULSE_NORM => 72,
+            PULSE_FAST => 100,
+            PULSE_2FAST => 150,
+            PULSE_THREADY => 200,
+            _ => 72
+        };
+    }
+
+    /// <summary>
+    /// Directly damage the heart organ at high pulses
+    /// </summary>
+    private void DamageHeart(EntityUid uid)
+    {
+        if (!TryComp<BodyComponent>(uid, out var body) || body.Organs == null)
+            return;
+
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            if (TryComp<HeartConditionComponent>(organ, out var heart))
+            {
+                heart.Efficiency = Math.Max(0, heart.Efficiency - 0.05f);
+                Dirty(organ, heart);
+                return;
+            }
+        }
+    }
+
+    private float GetBloodVolumeRatio(EntityUid uid)
+    {
+        if (!TryComp<BloodstreamComponent>(uid, out var bloodstream))
+            return 1.0f;
+
+        // BloodstreamComponent doesn't expose total volume easily
+        // so we calculate it from the solution
+        if (!_solution.ResolveSolution(uid, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution))
+            return 1.0f; // default to full if we can't resolve (less harmful than 0.5)
+
+        var refVol = bloodstream.BloodReferenceSolution.Volume;
+        if (refVol == 0)
+            return 1.0f;
+
+        var currentVol = bloodSolution.Volume;
+        return Math.Clamp((float)(currentVol / refVol), 0, 1);
+    }
+
+    private float GetLungEfficiency(EntityUid uid)
+    {
+        // Check the body's lung organs for condition
+        if (!TryComp<BodyComponent>(uid, out var body) || body.Organs == null)
+            return 1.0f;
+
+        var totalEff = 0f;
+        var count = 0;
+
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            if (TryComp<LungConditionComponent>(organ, out var lung))
+            {
+                totalEff += lung.Efficiency;
+                count++;
+            }
+        }
+
+        return count > 0 ? totalEff / count : 1.0f;
+    }
+
+    private float GetHeartEfficiency(EntityUid uid)
+    {
+        if (!TryComp<BodyComponent>(uid, out var body) || body.Organs == null)
+            return 1.0f;
+
+        var totalEff = 0f;
+        var count = 0;
+
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            if (TryComp<HeartConditionComponent>(organ, out var heart))
+            {
+                if (!heart.Beating)
+                    return 0f; // Heart not beating = zero output
+
+                totalEff += heart.Efficiency;
+                count++;
+            }
+        }
+
+        return count > 0 ? totalEff / count : 1.0f;
+    }
+
+    private float GetDexalinBonus(EntityUid uid)
+    {
+        if (!TryComp<BloodstreamComponent>(uid, out var bloodstream))
+            return 0f;
+
+        if (!_solution.ResolveSolution(uid, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution))
+            return 0f;
+
+        var dexalinAmount = bloodSolution.GetTotalPrototypeQuantity("DexalinPlus");
+        if (dexalinAmount > 0)
+            return DEXALIN_PLUS_BONUS;
+
+        dexalinAmount = bloodSolution.GetTotalPrototypeQuantity("Dexalin");
+        if (dexalinAmount > 0)
+            return DEXALIN_BONUS;
+
+        return 0f;
+    }
+
+    private bool HasInaprovaline(EntityUid uid)
+    {
+        if (!TryComp<BloodstreamComponent>(uid, out var stream))
+            return false;
+
+        if (!_solution.ResolveSolution(uid, stream.BloodSolutionName, ref stream.BloodSolution, out var blood))
+            return false;
+
+        return blood.GetTotalPrototypeQuantity("Inaprovaline") > 0;
+    }
+
+    private void ApplyOxygenEffects(EntityUid uid, BloodOxygenationComponent oxygenation)
+    {
+        if (oxygenation.Oxygenation >= O2_THRESHOLD_BRAIN_DAMAGE)
+        {
+            // Healthy - heal any accumulated brain damage slowly
+            if (oxygenation.AccumulatedBrainDamage > 0)
+            {
+                var heal = FixedPoint2.New(Math.Min(oxygenation.AccumulatedBrainDamage, 0.5f));
+                oxygenation.AccumulatedBrainDamage -= (float)heal;
+                TryApplyBrainDamage(uid, -heal);
+            }
+            return;
+        }
+
+        // Below threshold - deal brain damage proportional to deficit
+        var deficit = O2_THRESHOLD_BRAIN_DAMAGE - oxygenation.Oxygenation;
+        // Scale: at 85% O2 = 0 brain damage/tick, at 0% O2 = ~8.5 brain damage/tick
+        var damageAmount = FixedPoint2.New(deficit * 10f);
+
+        oxygenation.AccumulatedBrainDamage += (float)damageAmount;
+        TryApplyBrainDamage(uid, damageAmount);
+
+        // Below lethal threshold - rapid brain death
+        if (oxygenation.Oxygenation < O2_THRESHOLD_LETHAL)
+        {
+            var lethalDamage = FixedPoint2.New(5f);
+            oxygenation.AccumulatedBrainDamage += (float)lethalDamage;
+            TryApplyBrainDamage(uid, lethalDamage);
+        }
+    }
+
+    private void TryApplyBrainDamage(EntityUid uid, FixedPoint2 amount)
+    {
+        if (!TryComp<BodyComponent>(uid, out var body) || body.Organs == null)
+            return;
+
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            if (TryComp<BrainComponent>(organ, out var brain))
+            {
+                if (amount > 0)
+                    _brain.TakeBrainDamage((organ, brain), amount);
+                else
+                    _brain.HealBrainDamage((organ, brain), -amount);
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Set cardiac arrest state on an entity.
+    /// </summary>
+    public void SetCardiacArrest(EntityUid uid, BloodOxygenationComponent? oxygenation = null, bool arrest = true)
+    {
+        if (!Resolve(uid, ref oxygenation, logMissing: false))
+            return;
+
+        if (oxygenation.CardiacArrest == arrest)
+            return;
+
+        oxygenation.CardiacArrest = arrest;
+
+        if (arrest)
+        {
+            oxygenation.PulseLevel = PULSE_NONE;
+            oxygenation.PulseRate = 0;
+            oxygenation.Oxygenation = Math.Min(oxygenation.Oxygenation, 0.5f);
+
+            // Stop the heart
+            if (TryComp<BodyComponent>(uid, out var body) && body.Organs != null)
+            {
+                foreach (var organ in body.Organs.ContainedEntities)
+                {
+                    if (TryComp<HeartConditionComponent>(organ, out var heart))
+                    {
+                        heart.Beating = false;
+                        Dirty(organ, heart);
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Restart the heart, ending cardiac arrest.
+    /// </summary>
+    public bool RestartHeart(EntityUid uid)
+    {
+        if (!TryComp<BloodOxygenationComponent>(uid, out var oxygenation))
+            return false;
+
+        if (!oxygenation.CardiacArrest)
+            return false;
+
+        // Check underlying cause - if O2 is too low, heart will just stop again
+        if (oxygenation.Oxygenation < O2_THRESHOLD_LETHAL)
+            return false;
+
+        oxygenation.CardiacArrest = false;
+        oxygenation.PulseLevel = PULSE_SLOW;
+        oxygenation.PulseRate = PulseLevelToBPM(PULSE_SLOW);
+
+        // Restart the heart organ
+        if (TryComp<BodyComponent>(uid, out var body) && body.Organs != null)
+        {
+            foreach (var organ in body.Organs.ContainedEntities)
+            {
+                if (TryComp<HeartConditionComponent>(organ, out var heart))
+                {
+                    heart.Beating = true;
+                    Dirty(organ, heart);
+                }
+            }
+        }
+
+        return true;
+    }
+}
+// Baystation end

--- a/Content.Shared/Body/Systems/BrainSystem.BrainDamage.cs
+++ b/Content.Shared/Body/Systems/BrainSystem.BrainDamage.cs
@@ -1,0 +1,95 @@
+// Baystation start
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Events;
+using Content.Shared.FixedPoint;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+
+namespace Content.Shared.Body.Systems;
+
+public sealed partial class BrainSystem
+{
+    [Dependency] private MobThresholdSystem _mobThreshold = default!;
+    [Dependency] private MobStateSystem _mobState = default!;
+
+    /// <summary>
+    /// Apply brain damage, reducing brain integrity.
+    /// </summary>
+    public void TakeBrainDamage(Entity<BrainComponent> ent, FixedPoint2 amount)
+    {
+        if (amount <= 0 || TerminatingOrDeleted(ent))
+            return;
+
+        ent.Comp.Integrity = FixedPoint2.Max(ent.Comp.Integrity - amount, ent.Comp.MinDeadIntegrity);
+        Dirty(ent);
+
+        if (ent.Comp.Integrity <= ent.Comp.MinDeadIntegrity)
+        {
+            ent.Comp.HasBeenDead = true;
+            Dirty(ent);
+            OnBrainDeath(ent);
+        }
+    }
+
+    /// <summary>
+    /// Heal brain damage, restoring integrity.
+    /// </summary>
+    public void HealBrainDamage(Entity<BrainComponent> ent, FixedPoint2 amount)
+    {
+        if (amount <= 0 || TerminatingOrDeleted(ent))
+            return;
+
+        ent.Comp.Integrity = FixedPoint2.Min(ent.Comp.Integrity + amount, ent.Comp.MaxIntegrity);
+        Dirty(ent);
+    }
+
+    /// <summary>
+    /// Called when brain integrity reaches 0. Sets owner mob to Dead state.
+    /// </summary>
+    private void OnBrainDeath(Entity<BrainComponent> ent)
+    {
+        var body = FindBodyOwningBrain(ent);
+        if (body == null)
+            return;
+
+        var target = body.Value;
+
+        if (!_mobState.IsDead(target))
+        {
+            // Directly change mob state to dead, bypassing threshold system
+            if (TryComp<MobStateComponent>(target, out var mobState))
+            {
+                _mobState.ChangeMobState(target, MobState.Dead, mobState);
+            }
+        }
+
+        var ev = new BrainDeathEvent(target, ent);
+        RaiseLocalEvent(target, ref ev);
+    }
+
+    /// <summary>
+    /// Finds the body that contains this brain.
+    /// </summary>
+    private EntityUid? FindBodyOwningBrain(Entity<BrainComponent> ent)
+    {
+        if (TryComp<OrganComponent>(ent, out var organ) && organ.Body is { } body)
+            return body;
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets the current brain integrity percentage (0.0 - 1.0).
+    /// </summary>
+    public float GetBrainIntegrityPercent(Entity<BrainComponent> ent)
+    {
+        if (ent.Comp.MaxIntegrity == 0)
+            return 0f;
+
+        return (float)(ent.Comp.Integrity / ent.Comp.MaxIntegrity).Float();
+    }
+}
+
+
+// Baystation end

--- a/Content.Shared/Body/Systems/BrainSystem.cs
+++ b/Content.Shared/Body/Systems/BrainSystem.cs
@@ -1,3 +1,4 @@
+// Baystation start
 using Content.Shared.Body.Components;
 using Content.Shared.Ghost;
 using Content.Shared.Mind;
@@ -42,3 +43,4 @@ public sealed partial class BrainSystem : EntitySystem
         args.Cancel();
     }
 }
+// Baystation end

--- a/Content.Shared/Damage/Systems/LimbDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/LimbDamageSystem.cs
@@ -1,0 +1,287 @@
+// Baystation start
+using System.Linq;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Events;
+using Content.Shared.Body.Organs;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.FixedPoint;
+using Content.Shared.Projectiles;
+using Content.Shared.Weapons.Hitscan.Components;
+using Content.Shared.Weapons.Hitscan.Events;
+using Content.Shared.Weapons.Hitscan.Systems;
+using Content.Shared.Weapons.Melee;
+using Content.Shared.Weapons.Melee.Events;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Network;
+
+namespace Content.Shared.Damage.Systems;
+
+public sealed partial class LimbDamageSystem : EntitySystem
+{
+    [Dependency] private IPrototypeManager _prototypeManager = default!;
+    [Dependency] private DamageableSystem _damageable = default!;
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private INetManager _net = default!;
+
+    private readonly HashSet<ProtoId<DamageTypePrototype>> _bruteTypes = new()
+    {
+        "Blunt", "Slash", "Piercing"
+    };
+
+    private readonly HashSet<ProtoId<DamageTypePrototype>> _burnTypes = new()
+    {
+        "Heat", "Cold", "Shock", "Caustic"
+    };
+
+    private bool _processingMelee;
+    private bool _processingProjectile;
+    private bool _processingHitscan;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MeleeWeaponComponent, MeleeHitEvent>(OnMeleeHit, before: new[] { typeof(DamageableSystem) });
+        SubscribeLocalEvent<ProjectileComponent, ProjectileHitEvent>(OnProjectileHit, before: new[] { typeof(DamageableSystem) });
+        SubscribeLocalEvent<HitscanBasicRaycastComponent, HitscanRaycastFiredEvent>(OnHitscanHit, before: new[] { typeof(HitscanBasicDamageSystem) });
+        SubscribeLocalEvent<DamageableComponent, DamageChangedEvent>(OnDamageChanged);
+    }
+
+    /// <summary>
+    ///     Melee attacks hit a single random limb.
+    /// </summary>
+    private void OnMeleeHit(Entity<MeleeWeaponComponent> weapon, ref MeleeHitEvent ev)
+    {
+        if (!_net.IsServer)
+            return;
+
+        try
+        {
+            _processingMelee = true;
+
+            var processedAny = false;
+
+            foreach (var target in ev.HitEntities)
+            {
+                if (!TryComp<BodyComponent>(target, out var body) || body.Organs == null)
+                    continue;
+
+                var limbs = GetLimbs(target);
+                if (limbs.Count == 0)
+                {
+                    // No limbs to distribute to — let normal damage processing handle it
+                    continue;
+                }
+
+                var (brute, burn) = SplitDamage(ev.BaseDamage);
+                var limb = limbs[_random.Next(limbs.Count)];
+                ApplyToLimbComponent(limb, brute, burn);
+
+                _damageable.TryChangeDamage(target, ev.BaseDamage, origin: ev.User);
+                processedAny = true;
+            }
+
+            if (processedAny)
+                ev.Handled = true;
+        }
+        finally
+        {
+            _processingMelee = false;
+        }
+    }
+
+    /// <summary>
+    ///     Projectile hits should hit a single random limb (like melee).
+    ///     Fires before TryChangeDamage, so we just set a flag.
+    /// </summary>
+    private void OnProjectileHit(Entity<ProjectileComponent> projectile, ref ProjectileHitEvent args)
+    {
+        if (!_net.IsServer)
+            return;
+
+        _processingProjectile = true;
+    }
+
+    /// <summary>
+    ///     Hitscan (laser) hits should also hit a single random limb.
+    ///     Fires before TryChangeDamage, so we set a flag.
+    /// </summary>
+    private void OnHitscanHit(Entity<HitscanBasicRaycastComponent> gun, ref HitscanRaycastFiredEvent args)
+    {
+        if (!_net.IsServer)
+            return;
+
+        if (args.Data.HitEntity == null)
+            return;
+
+        _processingHitscan = true;
+    }
+
+    /// <summary>
+    ///     Untargeted damage (explosions, fire, environment) distributes across all limbs.
+    ///     Melee, projectile, and hitscan damage go to a single random limb.
+    /// </summary>
+    private void OnDamageChanged(Entity<DamageableComponent> ent, ref DamageChangedEvent args)
+    {
+        if (!_net.IsServer)
+            return;
+
+        if (args.DamageDelta == null || !args.DamageIncreased)
+            return;
+
+        // Skip if damage was already handled by melee limb targeting
+        if (_processingMelee)
+            return;
+
+        if (!TryComp<BodyComponent>(ent, out var body) || body.Organs == null)
+        {
+            _processingProjectile = false;
+            _processingHitscan = false;
+            return;
+        }
+
+        var limbs = GetLimbs(ent);
+        if (limbs.Count == 0)
+        {
+            _processingProjectile = false;
+            _processingHitscan = false;
+            return;
+        }
+
+        var (totalBrute, totalBurn) = SplitDamage(args.DamageDelta);
+
+        if (totalBrute <= 0 && totalBurn <= 0)
+        {
+            _processingProjectile = false;
+            _processingHitscan = false;
+            return;
+        }
+
+        // Projectile or hitscan: single random limb
+        if (_processingProjectile || _processingHitscan)
+        {
+            _processingProjectile = false;
+            _processingHitscan = false;
+            if (totalBrute > 0)
+            {
+                var bruteLimb = limbs[_random.Next(limbs.Count)];
+                ApplyToLimbComponent(bruteLimb, totalBrute, FixedPoint2.Zero);
+            }
+            if (totalBurn > 0)
+            {
+                var burnLimb = limbs[_random.Next(limbs.Count)];
+                ApplyToLimbComponent(burnLimb, FixedPoint2.Zero, totalBurn);
+            }
+            return;
+        }
+
+        // Untargeted damage: distribute across all limbs
+        var brutePerLimb = totalBrute / limbs.Count;
+        var burnPerLimb = totalBurn / limbs.Count;
+        var bruteRemainder = totalBrute - brutePerLimb * limbs.Count;
+        var burnRemainder = totalBurn - burnPerLimb * limbs.Count;
+
+        for (var i = 0; i < limbs.Count; i++)
+        {
+            var limb = limbs[i];
+            var addBrute = brutePerLimb;
+            var addBurn = burnPerLimb;
+
+            if (bruteRemainder > 0 && _random.Prob(0.5f))
+            {
+                addBrute += FixedPoint2.New(1);
+                bruteRemainder -= FixedPoint2.New(1);
+            }
+            if (burnRemainder > 0 && _random.Prob(0.5f))
+            {
+                addBurn += FixedPoint2.New(1);
+                burnRemainder -= FixedPoint2.New(1);
+            }
+
+            ApplyToLimbComponent(limb, addBrute, addBurn);
+        }
+    }
+
+    public void ApplyDamageToLimb(
+        EntityUid body,
+        EntityUid limbEntity,
+        DamageSpecifier damage,
+        bool ignoreResistances = false,
+        EntityUid? origin = null)
+    {
+        var (brute, burn) = SplitDamage(damage);
+
+        if (TryComp<ExternalOrganComponent>(limbEntity, out var externalOrgan))
+            ApplyToLimbComponent((limbEntity, externalOrgan), brute, burn);
+
+        _damageable.TryChangeDamage(body, damage, ignoreResistances, origin: origin);
+    }
+
+    public List<Entity<ExternalOrganComponent>> GetLimbs(EntityUid body)
+    {
+        var limbs = new List<Entity<ExternalOrganComponent>>();
+
+        if (!TryComp<BodyComponent>(body, out var bodyComp) || bodyComp.Organs == null)
+            return limbs;
+
+        foreach (var organ in bodyComp.Organs.ContainedEntities)
+        {
+            if (TryComp<ExternalOrganComponent>(organ, out var extOrgan))
+                limbs.Add((organ, extOrgan));
+        }
+
+        return limbs;
+    }
+
+    public (FixedPoint2 Brute, FixedPoint2 Burn) SplitDamage(DamageSpecifier damage)
+    {
+        FixedPoint2 brute = FixedPoint2.Zero;
+        FixedPoint2 burn = FixedPoint2.Zero;
+
+        foreach (var (type, value) in damage.DamageDict)
+        {
+            if (value <= 0)
+                continue;
+
+            if (_bruteTypes.Contains(type))
+                brute += value;
+            else if (_burnTypes.Contains(type))
+                burn += value;
+        }
+
+        return (brute, burn);
+    }
+
+    private void ApplyToLimbComponent(Entity<ExternalOrganComponent> limb, FixedPoint2 brute, FixedPoint2 burn)
+    {
+        limb.Comp.BruteDamage += brute;
+        limb.Comp.BurnDamage += burn;
+
+        if (limb.Comp.BruteDamage + limb.Comp.BurnDamage > limb.Comp.MaxDamage)
+        {
+            var excess = (limb.Comp.BruteDamage + limb.Comp.BurnDamage) - limb.Comp.MaxDamage;
+            var totalDamage = limb.Comp.BruteDamage + limb.Comp.BurnDamage;
+            if (totalDamage > 0)
+            {
+                var bruteFraction = limb.Comp.BruteDamage / totalDamage;
+                limb.Comp.BruteDamage -= excess * bruteFraction;
+                limb.Comp.BurnDamage -= excess * (1 - bruteFraction);
+            }
+        }
+
+        Dirty(limb);
+
+        if ((limb.Comp.Flags & LimbFlags.CanBreak) != 0 &&
+            limb.Comp.BruteDamage >= limb.Comp.MinBrokenDamage &&
+            (limb.Comp.Status & OrganStatusFlags.Broken) == 0)
+        {
+            var ev = new LimbFractureCheckEvent(limb, brute);
+            RaiseLocalEvent(limb, ref ev);
+        }
+    }
+}
+// Baystation end

--- a/Content.Shared/Medical/CPR/CPRComponent.cs
+++ b/Content.Shared/Medical/CPR/CPRComponent.cs
@@ -1,0 +1,26 @@
+// Baystation start
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared.Medical.CPR;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CPRComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool Active;
+
+    [DataField, AutoNetworkedField]
+    public float CardiacOutputModifier = 0.8f;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [AutoNetworkedField]
+    public TimeSpan ExpiryTime;
+
+    [DataField]
+    public TimeSpan Duration = TimeSpan.FromSeconds(3);
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? Performer;
+}
+// Baystation end

--- a/Content.Shared/Medical/CPR/CPRSystem.cs
+++ b/Content.Shared/Medical/CPR/CPRSystem.cs
@@ -1,0 +1,110 @@
+// Baystation start
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Systems;
+using Content.Shared.DoAfter;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Content.Shared.Timing;
+using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.Medical.CPR;
+
+public sealed partial class CPRSystem : EntitySystem
+{
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private BloodOxygenationSystem _bloodOxygenation = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CPRComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<CPRComponent, CPRDoAfterEvent>(OnDoAfter);
+        SubscribeLocalEvent<CPRComponent, InteractHandEvent>(OnInteractHand);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var curTime = _timing.CurTime;
+        var query = EntityQueryEnumerator<CPRComponent>();
+
+        while (query.MoveNext(out var uid, out var cpr))
+        {
+            if (!cpr.Active)
+                continue;
+
+            if (curTime < cpr.ExpiryTime)
+                continue;
+
+            var oldPerformer = cpr.Performer;
+            cpr.Active = false;
+            cpr.Performer = null;
+            Dirty(uid, cpr);
+
+            if (TryComp<BloodOxygenationComponent>(uid, out var oxygenation) && oxygenation.CardiacArrest)
+            {
+                if (oldPerformer != null)
+                    _popup.PopupEntity(Loc.GetString("cpr-expired", ("target", uid)), uid, oldPerformer.Value, PopupType.Medium);
+            }
+        }
+    }
+
+    private void OnInit(Entity<CPRComponent> ent, ref ComponentInit args)
+    {
+        ent.Comp.ExpiryTime = _timing.CurTime;
+    }
+
+    private void OnInteractHand(Entity<CPRComponent> ent, ref InteractHandEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!TryComp<BloodOxygenationComponent>(ent, out var oxygenation))
+            return;
+
+        if (!oxygenation.CardiacArrest)
+            return;
+
+        args.Handled = true;
+
+        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, ent.Comp.Duration, new CPRDoAfterEvent(), ent, target: ent, used: args.User)
+        {
+            BreakOnDamage = true,
+            BreakOnMove = true,
+            NeedHand = true,
+        };
+
+        _doAfter.TryStartDoAfter(doAfterArgs);
+    }
+
+    private void OnDoAfter(Entity<CPRComponent> ent, ref CPRDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled || args.Target is not { } target)
+            return;
+
+        if (!TryComp<BloodOxygenationComponent>(target, out var oxygenation))
+            return;
+
+        if (!oxygenation.CardiacArrest)
+            return;
+
+        ent.Comp.Active = true;
+        ent.Comp.Performer = args.User;
+        ent.Comp.ExpiryTime = _timing.CurTime + ent.Comp.Duration;
+        Dirty(target, ent.Comp);
+
+        _popup.PopupEntity(Loc.GetString("cpr-performing", ("performer", Identity.Entity(args.User, EntityManager)), ("target", target)), target, PopupType.Medium);
+
+        args.Handled = true;
+    }
+}
+
+[Serializable, NetSerializable]
+public sealed partial class CPRDoAfterEvent : SimpleDoAfterEvent;
+// Baystation end

--- a/Content.Shared/Medical/Pain/PainComponent.cs
+++ b/Content.Shared/Medical/Pain/PainComponent.cs
@@ -1,0 +1,25 @@
+// Baystation start
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared.Medical.Pain;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class PainComponent : Component
+{
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
+    public TimeSpan NextUpdate;
+
+    [DataField, AutoNetworkedField]
+    public float ShockLevel;
+
+    [DataField, AutoNetworkedField]
+    public float PainkillerLevel;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastPainMessageTime;
+
+    [DataField]
+    public string LastPainMessage = string.Empty;
+}
+// Baystation end

--- a/Content.Shared/Medical/Pain/PainSystem.cs
+++ b/Content.Shared/Medical/Pain/PainSystem.cs
@@ -1,0 +1,264 @@
+// Baystation start
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Organs;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.FixedPoint;
+using Content.Shared.Medical.Wounds;
+using Content.Shared.Popups;
+using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.Medical.Pain;
+
+public sealed partial class PainSystem : EntitySystem
+{
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private SharedSolutionContainerSystem _solution = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private INetManager _net = default!;
+    [Dependency] private IPrototypeManager _prototype = default!;
+    [Dependency] private IRobustRandom _random = default!;
+
+    private const float PARACETAMOL_PER_UNIT = 2.5f;
+    private const float TRAMADOL_PER_UNIT = 3.5f;
+    private const float OXYCODONE_PER_UNIT = 5.5f;
+
+    private const float PAIN_DECAY_PER_SECOND = 0.05f;
+    private const float BROKEN_PAIN = 10f;
+    private const float DISLOCATED_PAIN = 5f;
+    private const float BRUTE_PAIN_MULT = 0.7f;
+    private const float BURN_PAIN_MULT = 0.8f;
+
+    public TimeSpan UpdateInterval = TimeSpan.FromSeconds(1);
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<PainComponent, MapInitEvent>(OnMapInit);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var curTime = _timing.CurTime;
+        var query = EntityQueryEnumerator<PainComponent>();
+        while (query.MoveNext(out var uid, out var pain))
+        {
+            if (curTime < pain.NextUpdate)
+                continue;
+
+            pain.NextUpdate = curTime + UpdateInterval;
+
+            if (!TryComp<BodyComponent>(uid, out var body) || body.Organs == null)
+                continue;
+
+            var painkillerLevel = GetPainkillerLevel(uid);
+
+            var (maxLimbPain, worstOrgan, worstWoundable) = ComputePerLimbPain(body, painkillerLevel);
+
+            if (!_net.IsServer)
+            {
+                pain.PainkillerLevel = painkillerLevel;
+                pain.ShockLevel = maxLimbPain;
+                continue;
+            }
+
+            // Contextual pain message for the worst limb
+            if (worstOrgan is { } organ && worstWoundable is { } woundable)
+            {
+                HandlePainMessage(uid, organ, woundable, maxLimbPain, painkillerLevel, pain, curTime);
+
+                // Behavioral effects at high pain
+                if (maxLimbPain > 50 && _random.Prob(0.2f))
+                    TryDropItem(uid, organ);
+
+                if (maxLimbPain > 80 && _random.Prob(0.3f))
+                    TryStun(uid);
+            }
+
+            pain.PainkillerLevel = painkillerLevel;
+            pain.ShockLevel = maxLimbPain;
+        }
+    }
+
+    private void OnMapInit(Entity<PainComponent> ent, ref MapInitEvent args)
+    {
+        ent.Comp.ShockLevel = 0;
+        ent.Comp.PainkillerLevel = 0;
+        ent.Comp.LastPainMessageTime = TimeSpan.Zero;
+        ent.Comp.LastPainMessage = string.Empty;
+        ent.Comp.NextUpdate = _timing.CurTime + UpdateInterval;
+    }
+
+    private (float totalPain, EntityUid? worstOrgan, WoundableComponent? worstWoundable) ComputePerLimbPain(
+        BodyComponent body, float painkillerLevel)
+    {
+        float totalPain = 0;
+        EntityUid? worstOrgan = null;
+        WoundableComponent? worstWoundable = null;
+        var maxPain = 0f;
+
+        if (body.Organs == null)
+            return (0, null, null);
+
+        foreach (var organ in body.Organs.ContainedEntities)
+        {
+            if (!TryComp<ExternalOrganComponent>(organ, out var ext))
+                continue;
+
+            if (!TryComp<WoundableComponent>(organ, out var woundable))
+                continue;
+
+            // Decay persistent pain naturally
+            if (woundable.Pain > 0)
+            {
+                woundable.Pain = Math.Max(0, woundable.Pain - PAIN_DECAY_PER_SECOND * (float)UpdateInterval.TotalSeconds);
+                Dirty(organ, woundable);
+            }
+
+            var limbPain = woundable.Pain;
+
+            // Pain from wounds' Pain effects
+            foreach (var woundUid in woundable.Wounds)
+            {
+                if (TerminatingOrDeleted(woundUid))
+                    continue;
+
+                if (!TryComp<WoundEffectsComponent>(woundUid, out var effects))
+                    continue;
+
+                var painInstance = effects.GetEffect("Pain", _prototype);
+                if (painInstance == null)
+                    continue;
+
+                var painAmount = painInstance.GetFloatOrConfig("painAmount", _prototype);
+                var freshPain = painInstance.GetFloatOrConfig("freshPainAmount", _prototype);
+                limbPain += painAmount + freshPain;
+            }
+
+            // Pain from brute/burn damage (Baystation: 0.7*brute + 0.8*burn)
+            limbPain += (float)ext.BruteDamage.Float() * BRUTE_PAIN_MULT;
+            limbPain += (float)ext.BurnDamage.Float() * BURN_PAIN_MULT;
+
+            // Pain from broken bones
+            if ((ext.Status & OrganStatusFlags.Broken) != 0)
+                limbPain += BROKEN_PAIN;
+
+            // Pain from dislocation
+            if (ext.Dislocated)
+                limbPain += DISLOCATED_PAIN;
+
+            totalPain += limbPain;
+
+// Baystation: prefer the most-damaged organ but randomize 30% to add variety
+            if (limbPain > maxPain && (maxPain == 0 || _random.Prob(0.7f)))
+            {
+                maxPain = limbPain;
+                worstOrgan = organ;
+                worstWoundable = woundable;
+            }
+        }
+
+        return (totalPain, worstOrgan, worstWoundable);
+    }
+
+    private void HandlePainMessage(EntityUid uid, EntityUid organ, WoundableComponent woundable,
+        float limbPain, float painkillerLevel, PainComponent pain, TimeSpan curTime)
+    {
+        var effectivePain = limbPain - painkillerLevel * 0.5f;
+        if (effectivePain <= 0)
+            return;
+
+        // Anti-spam: same message within cooldown
+        var cooldown = TimeSpan.FromSeconds(Math.Max(2, 10 - effectivePain * 0.1));
+        if (curTime - pain.LastPainMessageTime < cooldown)
+            return;
+
+        var limbName = Name(organ);
+        var burning = TryComp<ExternalOrganComponent>(organ, out var ext) && ext.BurnDamage > ext.BruteDamage;
+
+        string msg;
+        if (effectivePain >= 60)
+            msg = Loc.GetString("pain-limb-extreme", ("limb", limbName), ("burning", burning ? "on fire" : "hurting terribly"));
+        else if (effectivePain >= 20)
+            msg = Loc.GetString("pain-limb-severe", ("limb", limbName), ("burning", burning ? "burns" : "hurts"));
+        else
+            msg = Loc.GetString("pain-limb-mild", ("limb", limbName), ("burning", burning ? "burns" : "hurts"));
+
+        // Anti-spam: skip if same message recently shown
+        if (msg == pain.LastPainMessage && curTime - pain.LastPainMessageTime < TimeSpan.FromSeconds(5))
+            return;
+
+        pain.LastPainMessage = msg;
+        pain.LastPainMessageTime = curTime;
+
+        _popup.PopupEntity(msg, uid, uid, PopupType.MediumCaution);
+
+        // Scream emote at high pain
+        if (effectivePain >= 40 && _random.Prob(Math.Min(effectivePain / 100f, 1f)))
+        {
+            var screamMsg = Loc.GetString("pain-scream-emote", ("target", uid));
+            _popup.PopupEntity(screamMsg, uid, uid, PopupType.LargeCaution);
+        }
+    }
+
+    private void TryDropItem(EntityUid uid, EntityUid organ)
+    {
+        if (!TryComp<ExternalOrganComponent>(organ, out var ext))
+            return;
+
+        if ((ext.Flags & LimbFlags.CanGrasp) == 0)
+            return;
+
+        // Find held items — simplified: trigger a drop via event or hands system
+        // For now, just raise a generic pain event
+        var ev = new PainDropItemEvent(uid);
+        RaiseLocalEvent(uid, ref ev);
+    }
+
+    private void TryStun(EntityUid uid)
+    {
+        var ev = new PainStunEvent(uid);
+        RaiseLocalEvent(uid, ref ev);
+    }
+
+    public void AddPainSpike(Entity<WoundableComponent> limb, float bruteAmount, float burnAmount)
+    {
+        var spikeAmount = bruteAmount * 0.4f + burnAmount * 0.6f;
+        limb.Comp.Pain += spikeAmount;
+        Dirty(limb.Owner, limb.Comp);
+    }
+
+    private float GetPainkillerLevel(EntityUid uid)
+    {
+        if (!TryComp<BloodstreamComponent>(uid, out var stream))
+            return 0;
+
+        if (!_solution.ResolveSolution(uid, stream.BloodSolutionName, ref stream.BloodSolution, out var blood))
+            return 0;
+
+        float level = 0;
+
+        var paraQty = (float)blood.GetTotalPrototypeQuantity("Paracetamol").Float();
+        level += paraQty * PARACETAMOL_PER_UNIT;
+
+        var tramQty = (float)blood.GetTotalPrototypeQuantity("Tramadol").Float();
+        level += tramQty * TRAMADOL_PER_UNIT;
+
+        var oxyQty = (float)blood.GetTotalPrototypeQuantity("Oxycodone").Float();
+        level += oxyQty * OXYCODONE_PER_UNIT;
+
+        return level;
+    }
+}
+
+[ByRefEvent]
+public record struct PainDropItemEvent(EntityUid uid);
+
+[ByRefEvent]
+public record struct PainStunEvent(EntityUid uid);
+// Baystation end

--- a/Content.Shared/Medical/Sterilizine/SterilizineComponent.cs
+++ b/Content.Shared/Medical/Sterilizine/SterilizineComponent.cs
@@ -1,0 +1,8 @@
+// Baystation start
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Medical.Sterilizine;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SterilizineComponent : Component;
+// Baystation end

--- a/Content.Shared/Medical/Wounds/WoundCapacityComponent.cs
+++ b/Content.Shared/Medical/Wounds/WoundCapacityComponent.cs
@@ -1,0 +1,18 @@
+// Baystation start
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Medical.Wounds;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class WoundCapacityComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public int DefaultCapacity = 3;
+
+    [DataField, AutoNetworkedField]
+    public Dictionary<string, int> GroupCapacity = new();
+
+    [DataField, AutoNetworkedField]
+    public int WeaponSpecificCapacity = 1;
+}
+// Baystation end

--- a/Content.Shared/Medical/Wounds/WoundComponent.cs
+++ b/Content.Shared/Medical/Wounds/WoundComponent.cs
@@ -1,0 +1,39 @@
+// Baystation start
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared.Medical.Wounds;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+public sealed partial class WoundComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier Damage = new();
+
+    [DataField(required: true), AutoNetworkedField]
+    public FixedPoint2 MaximumDamage;
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? ParentWoundable;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField, AutoNetworkedField]
+    public TimeSpan CreatedAt;
+
+    [DataField, AutoNetworkedField]
+    public int Stage;
+
+    [DataField, AutoNetworkedField]
+    public int MaxStages = 5;
+
+    [DataField, AutoNetworkedField]
+    public float HealPerTick;
+
+    [DataField, AutoNetworkedField]
+    public bool IsSurgical;
+
+    [DataField, AutoNetworkedField]
+    public string Group = string.Empty;
+}
+// Baystation end

--- a/Content.Shared/Medical/Wounds/WoundDescriptionComponent.cs
+++ b/Content.Shared/Medical/Wounds/WoundDescriptionComponent.cs
@@ -1,0 +1,12 @@
+// Baystation start
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared.Medical.Wounds;
+
+[RegisterComponent]
+public sealed partial class WoundDescriptionComponent : Component
+{
+    [DataField(required: true)]
+    public SortedDictionary<FixedPoint2, string> Descriptions = new();
+}
+// Baystation end

--- a/Content.Shared/Medical/Wounds/WoundEffectPrototype.cs
+++ b/Content.Shared/Medical/Wounds/WoundEffectPrototype.cs
@@ -1,0 +1,20 @@
+// Baystation start
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Medical.Wounds;
+
+[Prototype("woundEffect")]
+public sealed partial class WoundEffectPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = string.Empty;
+
+    [DataField(required: true)]
+    public string EffectType { get; private set; } = string.Empty;
+
+    [DataField]
+    public Dictionary<string, float> Config { get; private set; } = new();
+}
+// Baystation end

--- a/Content.Shared/Medical/Wounds/WoundEffectPrototype.cs
+++ b/Content.Shared/Medical/Wounds/WoundEffectPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Medical.Wounds;
 
-[Prototype("woundEffect")]
+[Prototype]
 public sealed partial class WoundEffectPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Medical/Wounds/WoundEffectsComponent.cs
+++ b/Content.Shared/Medical/Wounds/WoundEffectsComponent.cs
@@ -1,0 +1,81 @@
+// Baystation start
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Medical.Wounds;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class WoundEffectsComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public List<WoundEffectInstance> Effects = new();
+}
+
+[DataDefinition, Serializable, NetSerializable]
+public sealed partial class WoundEffectInstance
+{
+    [DataField(required: true)]
+    public ProtoId<WoundEffectPrototype> Id;
+
+    [DataField]
+    public Dictionary<string, float> FloatParams = new();
+
+    [DataField]
+    public List<string> StringListParams = new();
+}
+
+public static class WoundEffectsHelpers
+{
+    public static WoundEffectInstance? GetEffect(this WoundEffectsComponent comp, string effectType,
+        IPrototypeManager? protoMan = null)
+    {
+        foreach (var effect in comp.Effects)
+        {
+            var proto = protoMan?.Index(effect.Id);
+            if (proto?.EffectType == effectType)
+                return effect;
+        }
+        return null;
+    }
+
+    public static bool HasEffect(this WoundEffectsComponent comp, string effectType,
+        IPrototypeManager? protoMan = null)
+    {
+        return GetEffect(comp, effectType, protoMan) != null;
+    }
+
+    public static float GetFloat(this WoundEffectInstance instance, string key,
+        float defaultValue = 0)
+    {
+        if (instance.FloatParams.TryGetValue(key, out var val))
+            return val;
+        return defaultValue;
+    }
+
+    public static void SetFloat(this WoundEffectInstance instance, string key, float value)
+    {
+        instance.FloatParams[key] = value;
+    }
+
+    public static float GetConfigFloat(this WoundEffectInstance instance, string key,
+        IPrototypeManager protoMan)
+    {
+        var proto = protoMan.Index(instance.Id);
+        if (proto.Config.TryGetValue(key, out var val))
+            return val;
+        return 0;
+    }
+
+    public static float GetFloatOrConfig(this WoundEffectInstance instance, string key,
+        IPrototypeManager protoMan)
+    {
+        if (instance.FloatParams.TryGetValue(key, out var val))
+            return val;
+        var proto = protoMan.Index(instance.Id);
+        if (proto.Config.TryGetValue(key, out var configVal))
+            return configVal;
+        return 0;
+    }
+}
+// Baystation end

--- a/Content.Shared/Medical/Wounds/WoundEvents.cs
+++ b/Content.Shared/Medical/Wounds/WoundEvents.cs
@@ -1,0 +1,54 @@
+// Baystation start
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared.Medical.Wounds;
+
+/// <summary>
+///     Raised on a woundable when damage needs to be aggregated from all wounds.
+/// </summary>
+[ByRefEvent]
+public record struct GetWoundDamageEvent(DamageSpecifier Accumulator, DamageSpecifier? Tended);
+
+/// <summary>
+///     Raised to get total bleed amount from all wounds on a woundable.
+/// </summary>
+[ByRefEvent]
+public record struct GetBleedLevelEvent(FixedPoint2 BleedAmount);
+
+/// <summary>
+///     Raised to get total pain from all wounds on a woundable.
+/// </summary>
+[ByRefEvent]
+public record struct GetPainEvent(FixedPoint2 PainAmount, FixedPoint2 FreshPainAmount);
+
+/// <summary>
+///     Raised to find wounds with space for more damage.
+/// </summary>
+[ByRefEvent]
+public record struct GetWoundsWithSpaceEvent(DamageSpecifier Damage);
+
+/// <summary>
+///     Raised to heal wounds.
+/// </summary>
+[ByRefEvent]
+public record struct HealWoundsEvent(DamageSpecifier Damage);
+
+/// <summary>
+///     Raised to clamp wounds.
+/// </summary>
+[ByRefEvent]
+public record struct ClampWoundsEvent(FixedPoint2 Amount);
+
+/// <summary>
+///     Raised when woundable damage changes.
+/// </summary>
+[ByRefEvent]
+public record struct WoundableDamageChangedEvent;
+
+/// <summary>
+///     Raised to refresh wound state on a woundable.
+/// </summary>
+[ByRefEvent]
+public record struct RefreshWoundsEvent;
+// Baystation end

--- a/Content.Shared/Medical/Wounds/WoundExamineSystem.cs
+++ b/Content.Shared/Medical/Wounds/WoundExamineSystem.cs
@@ -1,0 +1,100 @@
+// Baystation start
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Organs;
+using Content.Shared.Examine;
+using Content.Shared.IdentityManagement;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Medical.Wounds;
+
+public sealed partial class WoundExamineSystem : EntitySystem
+{
+    [Dependency] private IPrototypeManager _prototype = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<WoundableComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<ExternalOrganComponent, ExaminedEvent>(OnExternalOrganExamined);
+    }
+
+    private void OnExamined(Entity<WoundableComponent> ent, ref ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        var wounds = ent.Comp.Wounds;
+        if (wounds == null || wounds.Count == 0)
+            return;
+
+        var hasEmbedded = false;
+        var woundCount = 0;
+        var worstStage = -1;
+
+        foreach (var woundUid in wounds)
+        {
+            if (TerminatingOrDeleted(woundUid))
+                continue;
+
+            woundCount++;
+
+            if (TryComp<WoundComponent>(woundUid, out var woundComp))
+            {
+                if (woundComp.Stage > worstStage)
+                    worstStage = woundComp.Stage;
+            }
+
+            if (TryComp<WoundEffectsComponent>(woundUid, out var effects))
+            {
+                var embedded = effects.GetEffect("Embedded", _prototype);
+                if (embedded is { StringListParams: { Count: > 0 } })
+                    hasEmbedded = true;
+            }
+        }
+
+        if (woundCount > 0)
+        {
+            args.PushMarkup(Loc.GetString("wound-examine-wounds-visible", ("count", woundCount)));
+
+            if (worstStage >= 0 && worstStage <= 4)
+                args.PushMarkup(Loc.GetString("wound-stage-" + worstStage));
+        }
+
+        if (hasEmbedded)
+            args.PushMarkup(Loc.GetString("wound-examine-embedded-objects"));
+    }
+
+    private void OnExternalOrganExamined(Entity<ExternalOrganComponent> ent, ref ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        var ext = ent.Comp;
+
+        if ((ext.Status & OrganStatusFlags.Broken) != 0)
+            args.PushMarkup(Loc.GetString("wound-examine-broken", ("limb", Name(ent))));
+
+        if ((ext.Status & OrganStatusFlags.CutAway) != 0)
+            args.PushMarkup(Loc.GetString("wound-examine-missing", ("limb", Name(ent))));
+
+        if ((ext.Status & OrganStatusFlags.ArteryCut) != 0)
+            args.PushMarkup(Loc.GetString("wound-examine-artery-cut", ("limb", Name(ent))));
+
+        if ((ext.Status & OrganStatusFlags.TendonCut) != 0)
+            args.PushMarkup(Loc.GetString("wound-examine-tendon-cut", ("limb", Name(ent))));
+
+        if (ext.Dislocated)
+            args.PushMarkup(Loc.GetString("wound-examine-dislocated", ("limb", Name(ent))));
+
+        if (ext.Disfigured)
+            args.PushMarkup(Loc.GetString("wound-examine-disfigured", ("limb", Name(ent))));
+
+        if ((ext.Status & OrganStatusFlags.Dead) != 0)
+            args.PushMarkup(Loc.GetString("wound-examine-necrotic", ("limb", Name(ent))));
+
+        if ((ext.Status & OrganStatusFlags.Bleeding) != 0)
+            args.PushMarkup(Loc.GetString("wound-examine-bleeding", ("limb", Name(ent))));
+    }
+}
+// Baystation end

--- a/Content.Shared/Medical/Wounds/WoundSystem.cs
+++ b/Content.Shared/Medical/Wounds/WoundSystem.cs
@@ -6,7 +6,6 @@ using Content.Shared.Body.Organs;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
-using Content.Shared.Body.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Damage.Systems;
 using Content.Shared.FixedPoint;

--- a/Content.Shared/Medical/Wounds/WoundSystem.cs
+++ b/Content.Shared/Medical/Wounds/WoundSystem.cs
@@ -1,0 +1,847 @@
+// Baystation start
+using System.Linq;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Organs;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.Body.Components;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Damage.Systems;
+using Content.Shared.FixedPoint;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Popups;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+using Robust.Shared.Network;
+
+namespace Content.Shared.Medical.Wounds;
+
+public sealed partial class WoundSystem : EntitySystem
+{
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private INetManager _net = default!;
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private IPrototypeManager _prototype = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private SharedSolutionContainerSystem _solution = default!;
+
+    private static readonly ProtoId<DamageTypePrototype>[] BruteTypes = { "Blunt", "Slash", "Piercing" };
+    private static readonly ProtoId<DamageTypePrototype>[] BurnTypes = { "Heat", "Cold", "Shock", "Caustic" };
+
+    private TimeSpan _nextUpdate;
+    public TimeSpan UpdateInterval = TimeSpan.FromSeconds(2);
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BodyComponent, DamageChangedEvent>(OnBodyDamageChanged);
+        SubscribeLocalEvent<WoundableComponent, GetWoundDamageEvent>(OnGetWoundDamage);
+        SubscribeLocalEvent<WoundComponent, GetBleedLevelEvent>(OnWoundGetBleed);
+        SubscribeLocalEvent<WoundComponent, GetPainEvent>(OnWoundGetPain);
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (!_net.IsServer)
+            return;
+
+        base.Update(frameTime);
+
+        var curTime = _timing.CurTime;
+        if (curTime < _nextUpdate)
+            return;
+
+        _nextUpdate = curTime + UpdateInterval;
+
+        var query = EntityQueryEnumerator<WoundableComponent>();
+        while (query.MoveNext(out var uid, out var woundable))
+        {
+            if (woundable.Wounds.RemoveAll(w => !Exists(w) || TerminatingOrDeleted(w)) > 0)
+                Dirty(uid, woundable);
+
+            var ev = new GetWoundDamageEvent(new(), new());
+            RaiseLocalEvent(uid, ref ev);
+            woundable.TotalDamage = ev.Accumulator;
+            woundable.TendedDamage = ev.Tended ?? new();
+            Dirty(uid, woundable);
+        }
+    }
+
+    private void OnBodyDamageChanged(Entity<BodyComponent> ent, ref DamageChangedEvent args)
+    {
+        if (!_net.IsServer)
+            return;
+
+        if (args.DamageDelta == null || !args.DamageIncreased)
+            return;
+
+        if (_timing.ApplyingState)
+            return;
+
+        var damage = DamageSpecifier.GetPositive(args.DamageDelta);
+        if (damage.Empty)
+            return;
+
+        if (ent.Comp.Organs == null)
+            return;
+
+        // Check for weapon-specific wound type override
+        EntProtoId? weaponWoundType = null;
+        if (args.Origin is { } origin && TryComp<WoundTypeOverrideComponent>(origin, out var overrideComp))
+            weaponWoundType = overrideComp.WoundType;
+
+        var wBlunt = SumTypes(damage, new ProtoId<DamageTypePrototype>[] { "Blunt" });
+        var wSlash = SumTypes(damage, new ProtoId<DamageTypePrototype>[] { "Slash" });
+        var wPierce = SumTypes(damage, new ProtoId<DamageTypePrototype>[] { "Piercing" });
+        var wBurn = SumTypes(damage, BurnTypes);
+
+        foreach (var organ in ent.Comp.Organs.ContainedEntities)
+        {
+            if (!TryComp<WoundableComponent>(organ, out var woundable))
+                continue;
+
+            if (TryComp<ExternalOrganComponent>(organ, out var ext))
+            {
+                var needsBruteWound = (wBlunt > 0 || wSlash > 0 || wPierce > 0);
+                var needsBurnWound = wBurn > 0;
+                var hasLimbBrute = ext.BruteDamage > 0;
+                var hasLimbBurn = ext.BurnDamage > 0;
+
+                if ((needsBruteWound && !hasLimbBrute) && (needsBurnWound && !hasLimbBurn))
+                    continue;
+
+                if (needsBruteWound && !hasLimbBrute)
+                    continue;
+                if (needsBurnWound && !hasLimbBurn)
+                    continue;
+            }
+
+            ProcessDamageForLimb((organ, woundable), ent.Owner, damage, weaponWoundType);
+        }
+    }
+
+    private void ProcessDamageForLimb(Entity<WoundableComponent> limb, EntityUid bodyUid, DamageSpecifier damage,
+        EntProtoId? weaponWoundType = null)
+    {
+        var blunt = SumTypes(damage, new ProtoId<DamageTypePrototype>[] { "Blunt" });
+        var slash = SumTypes(damage, new ProtoId<DamageTypePrototype>[] { "Slash" });
+        var pierce = SumTypes(damage, new ProtoId<DamageTypePrototype>[] { "Piercing" });
+        var burn = SumTypes(damage, BurnTypes);
+
+        var brute = blunt + slash + pierce;
+
+        // Brittle limb: 1.5x blunt damage
+        TryComp<ExternalOrganComponent>(limb, out var ext);
+        if (ext != null && (ext.Status & OrganStatusFlags.Brittle) != 0 && blunt > 0)
+        {
+            var extraBlunt = FixedPoint2.Min(blunt * 0.5f, FixedPoint2.New(100));
+            damage.DamageDict.TryGetValue("Blunt", out var existingBlunt);
+            damage.DamageDict["Blunt"] = existingBlunt + extraBlunt;
+            blunt += extraBlunt;
+            brute += extraBlunt;
+        }
+
+        if (weaponWoundType != null)
+        {
+            AddWeaponSpecificWound(limb, bodyUid, damage, weaponWoundType.Value);
+        }
+        else
+        {
+            if (blunt > 0)
+                AddDamageToWoundGroup(limb, bodyUid, damage, blunt, "Brute");
+            if (slash > 0)
+                AddDamageToWoundGroup(limb, bodyUid, damage, slash, "Cut");
+            if (pierce > 0)
+                AddDamageToWoundGroup(limb, bodyUid, damage, pierce, "Puncture");
+            if (burn > 0)
+                AddDamageToWoundGroup(limb, bodyUid, damage, burn, "Burn");
+        }
+
+        // Fluid loss from burns — severe burns cause blood loss from blistering
+        if (burn > 0 && ext != null && (ext.Status & OrganStatusFlags.Robotic) == 0 && _net.IsServer)
+        {
+            var burnFloat = burn.Float();
+            if (burnFloat > 5 && TryComp<BloodstreamComponent>(bodyUid, out var bloodstream)
+                && _solution.ResolveSolution(bodyUid, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution))
+            {
+                var fluidLoss = burnFloat * 0.01f;
+                _solution.RemoveReagent(bloodstream.BloodSolution!.Value, "Blood", FixedPoint2.New(fluidLoss));
+            }
+        }
+
+        // Damage triggers for limb conditions
+        if (ext != null && _net.IsServer)
+        {
+            var totalBrute = brute.Float();
+            var totalBurn = burn.Float();
+
+            // Artery cut: slash/pierce > 15 has a chance to sever artery
+            if ((ext.Flags & LimbFlags.HasTendon) != 0
+                && (ext.Status & OrganStatusFlags.ArteryCut) == 0
+                && (ext.Status & OrganStatusFlags.Robotic) == 0)
+            {
+                var sharpDamage = slash.Float() + pierce.Float();
+                if (sharpDamage > 15 && _random.Prob(Math.Min(sharpDamage, 75f) / 100f))
+                {
+                    ext.Status |= OrganStatusFlags.ArteryCut;
+                    Dirty(limb, ext);
+                    var msg = Loc.GetString("limb-artery-cut", ("limb", Name(limb)));
+                    _popup.PopupEntity(msg, bodyUid, bodyUid);
+                }
+            }
+
+            // Tendon cut: slash/pierce damage has a chance to sever tendon
+            if ((ext.Flags & LimbFlags.HasTendon) != 0
+                && (ext.Status & OrganStatusFlags.TendonCut) == 0
+                && (ext.Status & OrganStatusFlags.Robotic) == 0)
+            {
+                var sharpDamage = slash.Float() + pierce.Float();
+                if (sharpDamage > 10 && _random.Prob(Math.Min(sharpDamage / 4f, 50f) / 100f))
+                {
+                    ext.Status |= OrganStatusFlags.TendonCut;
+                    Dirty(limb, ext);
+                    var msg = Loc.GetString("limb-tendon-cut", ("limb", Name(limb)));
+                    _popup.PopupEntity(msg, bodyUid, bodyUid);
+                }
+            }
+
+            // Dislocation: high brute damage chance
+            if (!ext.Dislocated && (ext.Status & OrganStatusFlags.Robotic) == 0 && brute.Float() > 20
+                && (ext.Flags & LimbFlags.CanBreak) != 0)
+            {
+                if (_random.Prob(Math.Min(brute.Float() / 100f, 0.5f)))
+                {
+                    ext.Dislocated = true;
+                    Dirty(limb, ext);
+                    var msg = Loc.GetString("limb-dislocated", ("limb", Name(limb)));
+                    _popup.PopupEntity(msg, bodyUid, bodyUid);
+                }
+            }
+
+            // Disfigurement: severe damage to head
+            if (!ext.Disfigured && TryComp<OrganComponent>(limb, out var organComp)
+                && organComp.Category == "Head")
+            {
+                if (totalBrute > 30 || totalBurn > 20)
+                {
+                    if (_random.Prob(Math.Min((totalBrute + totalBurn) / 100f, 0.75f)))
+                    {
+                        ext.Disfigured = true;
+                        Dirty(limb, ext);
+                        var msg = Loc.GetString("limb-disfigured");
+                        _popup.PopupEntity(msg, bodyUid, bodyUid);
+                    }
+                }
+            }
+
+        }
+
+// Baystation: disturbing salved burns with brute damage removes the salve
+        if (blunt > 0 && ext != null && (ext.Status & OrganStatusFlags.Robotic) == 0 && _net.IsServer)
+        {
+            foreach (var woundUid in limb.Comp.Wounds)
+            {
+                if (TerminatingOrDeleted(woundUid))
+                    continue;
+                if (!TryComp<WoundEffectsComponent>(woundUid, out var wEffects))
+                    continue;
+                var salveEffect = wEffects.GetEffect("Salvable", _prototype);
+                if (salveEffect != null && salveEffect.GetFloat("salved") > 0 && blunt.Float() > 5)
+                {
+                    if (_random.Prob(0.3f))
+                    {
+                        salveEffect.SetFloat("salved", 0);
+                        Dirty(woundUid, wEffects);
+                    }
+                }
+            }
+        }
+
+    }
+
+    private void AddWeaponSpecificWound(Entity<WoundableComponent> limb, EntityUid bodyUid,
+        DamageSpecifier damage, EntProtoId woundProtoId)
+    {
+        var entCoords = Transform(limb.Owner).Coordinates;
+        var woundEnt = Spawn(woundProtoId, entCoords);
+
+        if (!TryComp<WoundComponent>(woundEnt, out var newWound))
+        {
+            Del(woundEnt);
+            return;
+        }
+
+        newWound.ParentWoundable = limb.Owner;
+        newWound.CreatedAt = _timing.CurTime;
+        var totalDamage = damage.GetTotal();
+        if (totalDamage > 0)
+            TransferDamage(newWound, damage, totalDamage, totalDamage);
+        Dirty(woundEnt, newWound);
+
+        InitializeWoundEffects(woundEnt);
+
+        limb.Comp.Wounds.Add(woundEnt);
+        Dirty(limb.Owner, limb.Comp);
+
+        MergeCompatibleWounds(limb);
+    }
+
+    private void InitializeWoundEffects(EntityUid woundEnt)
+    {
+        if (!TryComp<WoundEffectsComponent>(woundEnt, out var effects))
+            return;
+
+        foreach (var instance in effects.Effects)
+        {
+            var proto = _prototype.Index(instance.Id);
+            switch (proto.EffectType)
+            {
+                case "Bleeding":
+                    var baseAmount = instance.GetConfigFloat("baseBleedAmount", _prototype);
+                    instance.SetFloat("currentBleedAmount", baseAmount);
+                    var bleedTimer = instance.GetConfigFloat("bleedTimer", _prototype);
+                    instance.SetFloat("bleedTimer", bleedTimer);
+                    break;
+            }
+        }
+    }
+
+    private void OnGetWoundDamage(Entity<WoundableComponent> ent, ref GetWoundDamageEvent args)
+    {
+        foreach (var woundUid in ent.Comp.Wounds)
+        {
+            if (!TryComp<WoundComponent>(woundUid, out var wound) || TerminatingOrDeleted(woundUid))
+                continue;
+
+            foreach (var (type, value) in wound.Damage.DamageDict)
+            {
+                if (value == 0)
+                    continue;
+
+                AddToDict(args.Accumulator.DamageDict, type, value);
+
+                if (args.Tended == null)
+                    continue;
+
+                var tended = TryComp<WoundEffectsComponent>(woundUid, out var effects)
+                    && effects.GetEffect("Tendable", _prototype) is { } tendEffect
+                    && tendEffect.GetFloat("tended") > 0;
+                if (tended)
+                    AddToDict(args.Tended.DamageDict, type, value);
+            }
+        }
+    }
+
+    private void OnWoundGetBleed(Entity<WoundComponent> ent, ref GetBleedLevelEvent args)
+    {
+        if (!TryComp<WoundEffectsComponent>(ent, out var effects))
+            return;
+
+        var bleedInstance = effects.GetEffect("Bleeding", _prototype);
+        if (bleedInstance == null)
+            return;
+
+// Baystation: bruises only bleed at moderate+ severity (damage >= 20)
+        if (ent.Comp.Group == "Brute" && ent.Comp.Damage.GetTotal() < 20)
+            return;
+
+// Baystation: bleed timer — wound stops bleeding naturally when timer expires
+        var bleedTimer = bleedInstance.GetFloatOrConfig("bleedTimer", _prototype);
+        if (bleedTimer <= 0)
+            return;
+
+        var bleedAmount = bleedInstance.GetFloatOrConfig("currentBleedAmount", _prototype);
+        if (bleedAmount <= 0)
+            return;
+
+// Baystation: large embedded objects plug the wound and prevent bleeding
+        var embeddedInstance = effects.GetEffect("Embedded", _prototype);
+        if (embeddedInstance is { StringListParams: { Count: > 0 } })
+        {
+            // If there are embedded objects, the wound bleeds less (object plugs it)
+            args.BleedAmount += FixedPoint2.New(bleedAmount * 0.5f);
+            return;
+        }
+
+        var clampInstance = effects.GetEffect("Clampable", _prototype);
+        if (clampInstance != null && clampInstance.GetFloat("clamped") > 0)
+        {
+            args.BleedAmount += FixedPoint2.New(bleedAmount * 0.3f);
+            return;
+        }
+
+        var tendInstance = effects.GetEffect("Tendable", _prototype);
+        if (tendInstance != null && tendInstance.GetFloat("tended") > 0)
+        {
+            args.BleedAmount += FixedPoint2.New(bleedAmount * 0.1f);
+            return;
+        }
+
+        args.BleedAmount += FixedPoint2.New(bleedAmount);
+    }
+
+    private void OnWoundGetPain(Entity<WoundComponent> ent, ref GetPainEvent args)
+    {
+        if (!TryComp<WoundEffectsComponent>(ent, out var effects))
+            return;
+
+        var painInstance = effects.GetEffect("Pain", _prototype);
+        if (painInstance == null)
+            return;
+
+        var painAmount = painInstance.GetFloatOrConfig("painAmount", _prototype);
+        var freshPain = painInstance.GetFloatOrConfig("freshPainAmount", _prototype);
+
+        args.PainAmount += FixedPoint2.New(painAmount);
+        args.FreshPainAmount += FixedPoint2.New(freshPain);
+    }
+
+    private static FixedPoint2 SumTypes(DamageSpecifier damage, ProtoId<DamageTypePrototype>[] types)
+    {
+        FixedPoint2 total = FixedPoint2.Zero;
+        foreach (var type in types)
+        {
+            if (damage.DamageDict.TryGetValue(type, out var value) && value > 0)
+                total += value;
+        }
+        return total;
+    }
+
+    private static void AddToDict(Dictionary<ProtoId<DamageTypePrototype>, FixedPoint2> dict, ProtoId<DamageTypePrototype> key, FixedPoint2 value)
+    {
+        if (dict.TryGetValue(key, out var existing))
+            dict[key] = existing + value;
+        else
+            dict[key] = value;
+    }
+
+    private void AddDamageToWoundGroup(Entity<WoundableComponent> limb, EntityUid bodyUid,
+        DamageSpecifier damage, FixedPoint2 groupTotal, string groupName, EntityUid? origin = null)
+    {
+// Baystation: first try to worsen existing wounds (widen them) before filling space
+        if (TryWorsenExistingWounds(limb, damage, ref groupTotal, groupName))
+            return;
+
+        // Fill remaining capacity in existing wounds
+        foreach (var woundUid in limb.Comp.Wounds)
+        {
+            if (TerminatingOrDeleted(woundUid))
+                continue;
+            if (!TryComp<WoundComponent>(woundUid, out var wound))
+                continue;
+            if (!IsCorrectWoundGroup(woundUid, groupName))
+                continue;
+
+            var space = wound.MaximumDamage - wound.Damage.GetTotal();
+            if (space <= 0)
+                continue;
+
+            var toAdd = FixedPoint2.Min(groupTotal, space);
+            if (toAdd <= 0)
+                continue;
+
+            TransferDamage(wound, damage, groupTotal, toAdd);
+            groupTotal -= toAdd;
+            Dirty(woundUid, wound);
+            var refresh = new RefreshWoundsEvent();
+            RaiseLocalEvent(woundUid, ref refresh);
+            MergeCompatibleWounds(limb);
+        }
+
+        if (groupTotal <= 0)
+            return;
+
+        // Check capacity before spawning a new wound
+        if (IsCapacityReached(limb, bodyUid, groupName))
+        {
+            ReplaceOldestWound(limb, bodyUid, damage, groupTotal, groupName);
+            return;
+        }
+
+        SpawnNewWound(limb, damage, groupTotal, groupName);
+    }
+
+    /// <summary>
+    /// Baystation: try to worsen an existing compatible wound instead of creating a new one.
+    /// A wound can be worsened if it's the same damage type and the combined damage
+    /// doesn't exceed 1.5x the first stage's damage threshold.
+    /// Merged wounds (amount > 1) cannot be worsened.
+    /// </summary>
+    private bool TryWorsenExistingWounds(Entity<WoundableComponent> limb, DamageSpecifier damage,
+        ref FixedPoint2 groupTotal, string groupName)
+    {
+        foreach (var woundUid in limb.Comp.Wounds)
+        {
+            if (TerminatingOrDeleted(woundUid))
+                continue;
+            if (!TryComp<WoundComponent>(woundUid, out var wound))
+                continue;
+            if (!IsCorrectWoundGroup(woundUid, groupName))
+                continue;
+
+// Baystation: merged wounds (multiple wounds of same type stacked) can't be worsened
+            if (wound.Damage.GetTotal() > wound.MaximumDamage * 0.8f)
+                continue;
+
+            // Check if the wound can absorb more damage (1.5x first stage threshold)
+            // For our system, use 1.5x maximumDamage as the cap
+            var maxWorsenDmg = wound.MaximumDamage.Float() * 1.5f;
+            var currentDmg = wound.Damage.GetTotal().Float();
+            if (currentDmg + groupTotal.Float() > maxWorsenDmg)
+                continue;
+
+            // Worsen: add the damage directly to this wound
+            TransferDamage(wound, damage, groupTotal, groupTotal);
+            Dirty(woundUid, wound);
+            var refresh = new RefreshWoundsEvent();
+            RaiseLocalEvent(woundUid, ref refresh);
+            groupTotal = FixedPoint2.Zero;
+            MergeCompatibleWounds(limb);
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool IsCapacityReached(Entity<WoundableComponent> limb, EntityUid bodyUid, string groupName)
+    {
+        if (!TryComp<WoundCapacityComponent>(bodyUid, out var capacity))
+            return false;
+
+        var maxPerGroup = capacity.GroupCapacity.GetValueOrDefault(groupName, capacity.DefaultCapacity);
+        if (maxPerGroup <= 0)
+            return true;
+
+        var count = 0;
+        foreach (var woundUid in limb.Comp.Wounds)
+        {
+            if (TerminatingOrDeleted(woundUid))
+                continue;
+            if (!TryComp<WoundComponent>(woundUid, out var wound))
+                continue;
+            if (string.IsNullOrEmpty(wound.Group) || !wound.Group.Equals(groupName, StringComparison.OrdinalIgnoreCase))
+                continue;
+            count++;
+        }
+
+        return count >= maxPerGroup;
+    }
+
+    private void ReplaceOldestWound(Entity<WoundableComponent> limb, EntityUid bodyUid,
+        DamageSpecifier damage, FixedPoint2 groupTotal, string groupName)
+    {
+        EntityUid? oldestWound = null;
+        TimeSpan oldestTime = TimeSpan.MaxValue;
+
+        foreach (var woundUid in limb.Comp.Wounds)
+        {
+            if (TerminatingOrDeleted(woundUid))
+                continue;
+            if (!TryComp<WoundComponent>(woundUid, out var wound))
+                continue;
+            if (string.IsNullOrEmpty(wound.Group) || !wound.Group.Equals(groupName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (wound.CreatedAt < oldestTime)
+            {
+                oldestTime = wound.CreatedAt;
+                oldestWound = woundUid;
+            }
+        }
+
+        if (oldestWound is not { } remove)
+        {
+            SpawnNewWound(limb, damage, groupTotal, groupName);
+            return;
+        }
+
+        if (TryComp<WoundComponent>(remove, out var removeWound))
+        {
+            foreach (var (type, value) in removeWound.Damage.DamageDict)
+            {
+                if (value > 0)
+                {
+                    if (damage.DamageDict.TryGetValue(type, out var existing))
+                        damage.DamageDict[type] = existing + value;
+                    else
+                        damage.DamageDict[type] = value;
+                }
+            }
+            groupTotal += removeWound.Damage.GetTotal();
+        }
+
+        limb.Comp.Wounds.Remove(remove);
+        Del(remove);
+
+        SpawnNewWound(limb, damage, groupTotal, groupName);
+    }
+
+    private void SpawnNewWound(Entity<WoundableComponent> limb, DamageSpecifier damage,
+        FixedPoint2 groupTotal, string groupName, EntityUid? origin = null)
+    {
+        var protoId = PickWoundPrototype(groupName, groupTotal);
+        if (protoId == null)
+            return;
+
+        var entCoords = Transform(limb.Owner).Coordinates;
+        var woundEnt = Spawn(protoId, entCoords);
+
+        if (!TryComp<WoundComponent>(woundEnt, out var newWound))
+        {
+            Del(woundEnt);
+            return;
+        }
+
+        newWound.ParentWoundable = limb.Owner;
+        newWound.CreatedAt = _timing.CurTime;
+        TransferDamage(newWound, damage, groupTotal, groupTotal);
+        Dirty(woundEnt, newWound);
+
+        InitializeWoundEffects(woundEnt);
+
+        // Embedded objects from puncture damage (shrapnel/bullets)
+        if (groupName == "Puncture" && groupTotal.Float() >= 10 && _net.IsServer)
+        {
+            if (_random.Prob(Math.Min(groupTotal.Float() / 50f, 0.5f)))
+            {
+                var effects = EnsureComp<WoundEffectsComponent>(woundEnt);
+                var embedded = effects.GetEffect("Embedded", _prototype);
+                if (embedded != null)
+                {
+                    embedded.StringListParams.Add("shrapnel");
+                    Dirty(woundEnt, effects);
+                }
+                else
+                {
+                    var newEmbedded = new WoundEffectInstance { Id = "Embedded" };
+                    newEmbedded.StringListParams.Add("shrapnel");
+                    effects.Effects.Add(newEmbedded);
+                    Dirty(woundEnt, effects);
+                }
+            }
+        }
+
+        limb.Comp.Wounds.Add(woundEnt);
+        Dirty(limb.Owner, limb.Comp);
+
+        MergeCompatibleWounds(limb);
+    }
+
+    private void MergeCompatibleWounds(Entity<WoundableComponent> limb)
+    {
+        var wounds = limb.Comp.Wounds.ToList();
+        for (var i = 0; i < wounds.Count; i++)
+        {
+            var a = wounds[i];
+            if (TerminatingOrDeleted(a) || !TryComp<WoundComponent>(a, out var wa))
+                continue;
+
+            for (var j = i + 1; j < wounds.Count; j++)
+            {
+                var b = wounds[j];
+                if (TerminatingOrDeleted(b) || !TryComp<WoundComponent>(b, out var wb))
+                    continue;
+
+                if (!IsSameGroup(a, b))
+                    continue;
+
+                // Check same treatment state via WoundEffectsComponent
+                if (!IsSameTreatmentState(a, b))
+                    continue;
+
+                EntityUid keep, remove;
+                WoundComponent wk, wr;
+
+                if (wa.MaximumDamage >= wb.MaximumDamage)
+                {
+                    keep = a; wk = wa; remove = b; wr = wb;
+                }
+                else
+                {
+                    keep = b; wk = wb; remove = a; wr = wa;
+                }
+
+                var combined = wk.Damage.GetTotal() + wr.Damage.GetTotal();
+                if (combined > wk.MaximumDamage)
+                {
+                    var groupName = GetWoundGroup(keep);
+                    if (string.IsNullOrEmpty(groupName))
+                        continue;
+
+                    var newProto = PickWoundPrototype(groupName, combined);
+                    if (newProto == null)
+                        continue;
+
+                    var entCoords = Transform(limb.Owner).Coordinates;
+                    var newWoundEnt = Spawn(newProto, entCoords);
+                    if (!TryComp<WoundComponent>(newWoundEnt, out var newWc))
+                    {
+                        Del(newWoundEnt);
+                        continue;
+                    }
+
+                    newWc.ParentWoundable = limb.Owner;
+                    newWc.CreatedAt = _timing.CurTime;
+                    foreach (var (type, value) in wk.Damage.DamageDict)
+                    {
+                        if (value > 0)
+                            newWc.Damage.DamageDict[type] = value;
+                    }
+                    foreach (var (type, value) in wr.Damage.DamageDict)
+                    {
+                        if (value <= 0)
+                            continue;
+                        if (newWc.Damage.DamageDict.TryGetValue(type, out var existing))
+                            newWc.Damage.DamageDict[type] = existing + value;
+                        else
+                            newWc.Damage.DamageDict[type] = value;
+                    }
+                    Dirty(newWoundEnt, newWc);
+
+                    InitializeWoundEffects(newWoundEnt);
+
+                    limb.Comp.Wounds.Remove(keep);
+                    limb.Comp.Wounds.Remove(remove);
+                    limb.Comp.Wounds.Add(newWoundEnt);
+                    Dirty(limb.Owner, limb.Comp);
+                    Del(keep);
+                    Del(remove);
+
+                    return;
+                }
+
+                foreach (var (type, value) in wr.Damage.DamageDict)
+                {
+                    if (value <= 0)
+                        continue;
+                    if (wk.Damage.DamageDict.TryGetValue(type, out var existing))
+                        wk.Damage.DamageDict[type] = existing + value;
+                    else
+                        wk.Damage.DamageDict[type] = value;
+                }
+
+                Dirty(keep, wk);
+
+                limb.Comp.Wounds.Remove(remove);
+                Dirty(limb.Owner, limb.Comp);
+                Del(remove);
+            }
+        }
+    }
+
+    private bool IsSameTreatmentState(EntityUid a, EntityUid b)
+    {
+        var aTended = TryComp<WoundEffectsComponent>(a, out var ea)
+            && ea.GetEffect("Tendable", _prototype) is { } ta
+            && ta.GetFloat("tended") > 0;
+        var bTended = TryComp<WoundEffectsComponent>(b, out var eb)
+            && eb.GetEffect("Tendable", _prototype) is { } tb
+            && tb.GetFloat("tended") > 0;
+        return aTended == bTended;
+    }
+
+    private bool IsSameGroup(EntityUid a, EntityUid b)
+    {
+        return GetWoundGroup(a) == GetWoundGroup(b);
+    }
+
+    private string GetWoundGroup(EntityUid wound)
+    {
+        if (TryComp<WoundComponent>(wound, out var wc) && !string.IsNullOrEmpty(wc.Group))
+            return wc.Group;
+
+        if (TryComp<WoundDescriptionComponent>(wound, out var desc))
+        {
+            foreach (var text in desc.Descriptions.Values)
+            {
+                if (text.Contains("brute", StringComparison.OrdinalIgnoreCase)) return "brute";
+                if (text.Contains("cut", StringComparison.OrdinalIgnoreCase)) return "cut";
+                if (text.Contains("puncture", StringComparison.OrdinalIgnoreCase)) return "puncture";
+                if (text.Contains("burn", StringComparison.OrdinalIgnoreCase)) return "burn";
+                if (text.Contains("incision", StringComparison.OrdinalIgnoreCase)) return "incision";
+            }
+        }
+        return "";
+    }
+
+    private bool IsCorrectWoundGroup(EntityUid woundUid, string groupName)
+    {
+        if (TryComp<WoundComponent>(woundUid, out var wc) &&
+            !string.IsNullOrEmpty(wc.Group) &&
+            wc.Group.Equals(groupName, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (TryComp<WoundDescriptionComponent>(woundUid, out var desc))
+        {
+            foreach (var text in desc.Descriptions.Values)
+            {
+                if (text.Contains(groupName, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void TransferDamage(WoundComponent wound, DamageSpecifier source, FixedPoint2 sourceTotal, FixedPoint2 amount)
+    {
+        if (sourceTotal <= 0)
+            return;
+
+        var ratio = (float)(amount / sourceTotal).Float();
+        foreach (var (type, value) in source.DamageDict)
+        {
+            if (value <= 0)
+                continue;
+
+            var toTransfer = FixedPoint2.New(value.Float() * ratio);
+
+            if (wound.Damage.DamageDict.TryGetValue(type, out var existing))
+                wound.Damage.DamageDict[type] = existing + toTransfer;
+            else
+                wound.Damage.DamageDict[type] = toTransfer;
+        }
+    }
+
+    private static string? PickWoundPrototype(string groupName, FixedPoint2 amount)
+    {
+        var severity = amount.Float();
+        var suffix = (groupName, severity) switch
+        {
+            ("Brute", >= 80) => "Monumental",
+            ("Brute", >= 50) => "Huge",
+            ("Brute", >= 30) => "Large",
+            ("Brute", >= 20) => "Moderate",
+            ("Brute", >= 10) => "Small",
+            ("Brute", _) => "Tiny",
+
+            ("Burn", >= 50) => "Carbonised",
+            ("Burn", >= 40) => "Deep",
+            ("Burn", >= 30) => "Severe",
+            ("Burn", >= 15) => "Large",
+            ("Burn", >= 10) => "Moderate",
+            ("Burn", _) => "Small",
+
+            ("Cut", >= 50) => "Massive",
+            ("Cut", >= 25) => "Gaping",
+            ("Cut", >= 15) => "Flesh",
+            ("Cut", >= 10) => "Deep",
+            ("Cut", _) => "Small",
+
+            ("Puncture", >= 30) => "Massive",
+            ("Puncture", >= 15) => "Gaping",
+            ("Puncture", >= 10) => "Flesh",
+            ("Puncture", _) => "Small",
+
+            _ => null
+        };
+
+        return suffix != null ? $"Wound{groupName}{suffix}" : null;
+    }
+}
+// Baystation end

--- a/Content.Shared/Medical/Wounds/WoundSystem.cs
+++ b/Content.Shared/Medical/Wounds/WoundSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Damage.Systems;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Popups;
+using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -27,6 +28,7 @@ public sealed partial class WoundSystem : EntitySystem
     [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedSolutionContainerSystem _solution = default!;
+    [Dependency] private SharedContainerSystem _container = default!;
 
     private static readonly ProtoId<DamageTypePrototype>[] BruteTypes = { "Blunt", "Slash", "Piercing" };
     private static readonly ProtoId<DamageTypePrototype>[] BurnTypes = { "Heat", "Cold", "Shock", "Caustic" };
@@ -283,6 +285,7 @@ public sealed partial class WoundSystem : EntitySystem
         Dirty(woundEnt, newWound);
 
         InitializeWoundEffects(woundEnt);
+        InsertWoundInContainer(woundEnt, limb);
 
         limb.Comp.Wounds.Add(woundEnt);
         Dirty(limb.Owner, limb.Comp);
@@ -703,6 +706,7 @@ public sealed partial class WoundSystem : EntitySystem
                     Dirty(newWoundEnt, newWc);
 
                     InitializeWoundEffects(newWoundEnt);
+                    InsertWoundInContainer(newWoundEnt, limb);
 
                     limb.Comp.Wounds.Remove(keep);
                     limb.Comp.Wounds.Remove(remove);
@@ -841,6 +845,21 @@ public sealed partial class WoundSystem : EntitySystem
         };
 
         return suffix != null ? $"Wound{groupName}{suffix}" : null;
+    }
+
+    private void InsertWoundInContainer(EntityUid woundEnt, Entity<WoundableComponent> limb)
+    {
+        var bodyUid = Transform(limb.Owner).ParentUid;
+        if (!HasComp<BodyComponent>(bodyUid))
+            return;
+
+        if (!TryComp<ContainerManagerComponent>(bodyUid, out var containerComp))
+            containerComp = AddComp<ContainerManagerComponent>(bodyUid);
+
+        if (!_container.TryGetContainer(bodyUid, BodyComponent.WoundContainerID, out var container, containerComp))
+            container = _container.MakeContainer<Container>(bodyUid, BodyComponent.WoundContainerID, containerComp);
+
+        _container.Insert(woundEnt, container);
     }
 }
 // Baystation end

--- a/Content.Shared/Medical/Wounds/WoundSystem.cs
+++ b/Content.Shared/Medical/Wounds/WoundSystem.cs
@@ -11,7 +11,7 @@ using Content.Shared.Damage.Systems;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Popups;
-using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -28,7 +28,7 @@ public sealed partial class WoundSystem : EntitySystem
     [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedSolutionContainerSystem _solution = default!;
-    [Dependency] private SharedContainerSystem _container = default!;
+    [Dependency] private EntityLookupSystem _lookup = default!;
 
     private static readonly ProtoId<DamageTypePrototype>[] BruteTypes = { "Blunt", "Slash", "Piercing" };
     private static readonly ProtoId<DamageTypePrototype>[] BurnTypes = { "Heat", "Cold", "Shock", "Caustic" };
@@ -285,7 +285,7 @@ public sealed partial class WoundSystem : EntitySystem
         Dirty(woundEnt, newWound);
 
         InitializeWoundEffects(woundEnt);
-        InsertWoundInContainer(woundEnt, limb);
+        RemoveWoundFromBroadphase(woundEnt);
 
         limb.Comp.Wounds.Add(woundEnt);
         Dirty(limb.Owner, limb.Comp);
@@ -706,7 +706,7 @@ public sealed partial class WoundSystem : EntitySystem
                     Dirty(newWoundEnt, newWc);
 
                     InitializeWoundEffects(newWoundEnt);
-                    InsertWoundInContainer(newWoundEnt, limb);
+                    RemoveWoundFromBroadphase(newWoundEnt);
 
                     limb.Comp.Wounds.Remove(keep);
                     limb.Comp.Wounds.Remove(remove);
@@ -847,19 +847,10 @@ public sealed partial class WoundSystem : EntitySystem
         return suffix != null ? $"Wound{groupName}{suffix}" : null;
     }
 
-    private void InsertWoundInContainer(EntityUid woundEnt, Entity<WoundableComponent> limb)
+    private void RemoveWoundFromBroadphase(EntityUid woundEnt)
     {
-        var bodyUid = Transform(limb.Owner).ParentUid;
-        if (!HasComp<BodyComponent>(bodyUid))
-            return;
-
-        if (!TryComp<ContainerManagerComponent>(bodyUid, out var containerComp))
-            containerComp = AddComp<ContainerManagerComponent>(bodyUid);
-
-        if (!_container.TryGetContainer(bodyUid, BodyComponent.WoundContainerID, out var container, containerComp))
-            container = _container.MakeContainer<Container>(bodyUid, BodyComponent.WoundContainerID, containerComp);
-
-        _container.Insert(woundEnt, container);
+        var xform = Transform(woundEnt);
+        _lookup.RemoveFromEntityTree(woundEnt, xform);
     }
 }
 // Baystation end

--- a/Content.Shared/Medical/Wounds/WoundTypeOverrideComponent.cs
+++ b/Content.Shared/Medical/Wounds/WoundTypeOverrideComponent.cs
@@ -1,0 +1,13 @@
+// Baystation start
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Medical.Wounds;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class WoundTypeOverrideComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntProtoId? WoundType;
+}
+// Baystation end

--- a/Content.Shared/Medical/Wounds/WoundableComponent.cs
+++ b/Content.Shared/Medical/Wounds/WoundableComponent.cs
@@ -1,0 +1,24 @@
+// Baystation start
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared.Medical.Wounds;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class WoundableComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public List<EntityUid> Wounds = new();
+
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier TotalDamage = new();
+
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier TendedDamage = new();
+
+    [DataField, AutoNetworkedField]
+    public float Pain;
+}
+// Baystation end

--- a/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
+++ b/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
@@ -1,10 +1,9 @@
+// Baystation start
+using Content.Shared.FixedPoint;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.MedicalScanner;
 
-/// <summary>
-/// On interacting with an entity retrieves the entity UID for use with getting the current damage of the mob.
-/// </summary>
 [Serializable, NetSerializable]
 public sealed class HealthAnalyzerScannedUserMessage : BoundUserInterfaceMessage
 {
@@ -16,9 +15,23 @@ public sealed class HealthAnalyzerScannedUserMessage : BoundUserInterfaceMessage
     }
 }
 
-/// <summary>
-/// Contains the current state of a health analyzer control. Used for the health analyzer and cryo pod.
-/// </summary>
+[Serializable, NetSerializable]
+public struct LimbScanData
+{
+    public string Name;
+    public FixedPoint2 BruteDamage;
+    public FixedPoint2 BurnDamage;
+    public bool Fractured;
+    public bool Bleeding;
+}
+
+[Serializable, NetSerializable]
+public struct ReagentScanData
+{
+    public string Name;
+    public FixedPoint2 Quantity;
+}
+
 [Serializable, NetSerializable]
 public struct HealthAnalyzerUiState
 {
@@ -29,9 +42,31 @@ public struct HealthAnalyzerUiState
     public bool? Bleeding;
     public bool? Unrevivable;
 
-    public HealthAnalyzerUiState() {}
+// Baystation fields
+    public string BrainActivity; // "Normal", "Fading", "None"
+    public float PulseRate;
+    public float BloodOxygenation;
+    public int TotalDamage;
+    public List<LimbScanData> Limbs;
+    public List<ReagentScanData> Reagents;
+    public bool HasFractures;
+    public bool HasInternalBleeding;
+    public bool HasOrganFailure;
 
-    public HealthAnalyzerUiState(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, bool? unrevivable)
+    public HealthAnalyzerUiState()
+    {
+        BrainActivity = "Normal";
+        Limbs = new();
+        Reagents = new();
+    }
+
+    public HealthAnalyzerUiState(
+        NetEntity? targetEntity,
+        float temperature,
+        float bloodLevel,
+        bool? scanMode,
+        bool? bleeding,
+        bool? unrevivable)
     {
         TargetEntity = targetEntity;
         Temperature = temperature;
@@ -39,5 +74,11 @@ public struct HealthAnalyzerUiState
         ScanMode = scanMode;
         Bleeding = bleeding;
         Unrevivable = unrevivable;
+        BrainActivity = "Normal";
+        PulseRate = 0;
+        BloodOxygenation = 0;
+        Limbs = new();
+        Reagents = new();
     }
 }
+// Baystation end

--- a/Resources/Locale/en-US/medical/components/pain-component.ftl
+++ b/Resources/Locale/en-US/medical/components/pain-component.ftl
@@ -1,0 +1,42 @@
+# Baystation start
+# Pain popup messages
+pain-limb-mild = Your {$limb} {$burning}.
+pain-limb-severe = Your {$limb} {$burning} badly!
+pain-limb-extreme = OH GOD! Your {$limb} is {$burning}!
+
+pain-internal-head = Your head pounds with a dull ache.
+pain-toxin-mild = Your body stings slightly.
+pain-toxin-moderate = Your body stings.
+pain-toxin-severe = Your body stings strongly.
+pain-toxin-extreme = Your whole body hurts badly.
+
+pain-scream-emote = {CAPITALIZE(SUBJECT($target))} screams in pain!
+
+# Examine messages
+wound-examine-wounds-visible = There are {$count} visible wound(s).
+wound-examine-embedded-objects = There are embedded objects in the wounds.
+wound-examine-broken = The {$limb} is broken.
+wound-examine-missing = The {$limb} is missing.
+wound-examine-artery-cut = The {$limb} has a severed artery.
+wound-examine-tendon-cut = The {$limb} has a severed tendon.
+wound-examine-dislocated = The {$limb} is dislocated.
+wound-examine-disfigured = The {$limb} is disfigured beyond recognition.
+wound-examine-necrotic = The {$limb} is necrotic.
+wound-examine-bleeding = The {$limb} is bleeding.
+
+# Wound stage descriptions (0=worst, 4=almost healed)
+wound-stage-0 = severe wound
+wound-stage-1 = large wound
+wound-stage-2 = moderate wound
+wound-stage-3 = healing wound
+wound-stage-4 = nearly healed
+
+# Limb damage event messages
+limb-artery-cut = You feel a sharp rip as an artery in your {$limb} is severed!
+limb-tendon-cut = You feel a snap as a tendon in your {$limb} is severed!
+limb-dislocated = Your {$limb} is dislocated!
+limb-disfigured = Your face is horribly disfigured!
+limb-necrotic = You can't feel your {$limb} anymore...
+limb-broken-hit-scream = {CAPITALIZE(SUBJECT($target))} screams in pain!
+limb-jostle-bone-pain = A piece of bone shifts painfully in your {$limb}!
+# Baystation end

--- a/Resources/Locale/en-US/medical/components/sterilizine-component.ftl
+++ b/Resources/Locale/en-US/medical/components/sterilizine-component.ftl
@@ -1,0 +1,4 @@
+# Baystation start
+sterilizine-applied = You sterilize {$count} wound(s).
+sterilizine-no-effect = There are no infected wounds to treat.
+# Baystation end

--- a/Resources/Locale/en-US/reagents/meta/sterilizine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/sterilizine.ftl
@@ -1,0 +1,5 @@
+# Baystation start
+reagent-name-sterilizine = Sterilizine
+reagent-desc-sterilizine = A powerful sterilizing agent that cleans wounds and prevents infection.
+reagent-physical-desc-sterilizine = A pale green, translucent fluid.
+# Baystation end

--- a/Resources/Prototypes/Body/Species/human.yml
+++ b/Resources/Prototypes/Body/Species/human.yml
@@ -1,3 +1,4 @@
+# Baystation start
 - type: markingsGroup
   parent: Undergarments
   id: Human
@@ -132,10 +133,19 @@
   - type: VisualOrganMarkings
     markingData:
       group: Human
+  - type: Woundable
 
 - type: entity
   parent: [ OrganBaseTorsoSexed, OrganBaseTorso, OrganHumanExternal ]
   id: OrganHumanTorso
+  components:
+  - type: ExternalOrgan
+    maxDamage: 200
+    minBrokenDamage: 150
+    flags:
+    - CanAmputate
+    - CanBreak
+    - HasTendon
 
 - type: entity
   parent: [ OrganBaseHeadSexed, OrganBaseHead, OrganHumanExternal ]
@@ -145,38 +155,117 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.Hair
     - enum.HumanoidVisualLayers.Snout
+  - type: ExternalOrgan
+    maxDamage: 100
+    minBrokenDamage: 40
+    flags:
+    - CanAmputate
+    - CanBreak
+    - HasTendon
 
 - type: entity
   parent: [ OrganBaseArmLeft, OrganHumanExternal ]
   id: OrganHumanArmLeft
+  components:
+  - type: ExternalOrgan
+    maxDamage: 80
+    minBrokenDamage: 50
+    flags:
+    - CanAmputate
+    - CanBreak
+    - CanGrasp
+    - HasTendon
 
 - type: entity
   parent: [ OrganBaseArmRight, OrganHumanExternal ]
   id: OrganHumanArmRight
+  components:
+  - type: ExternalOrgan
+    maxDamage: 80
+    minBrokenDamage: 50
+    flags:
+    - CanAmputate
+    - CanBreak
+    - CanGrasp
+    - HasTendon
 
 - type: entity
   parent: [ OrganBaseHandLeft, OrganHumanExternal ]
   id: OrganHumanHandLeft
+  components:
+  - type: ExternalOrgan
+    maxDamage: 50
+    minBrokenDamage: 30
+    flags:
+    - CanAmputate
+    - CanBreak
+    - CanGrasp
+    - HasTendon
 
 - type: entity
   parent: [ OrganBaseHandRight, OrganHumanExternal ]
   id: OrganHumanHandRight
+  components:
+  - type: ExternalOrgan
+    maxDamage: 50
+    minBrokenDamage: 30
+    flags:
+    - CanAmputate
+    - CanBreak
+    - CanGrasp
+    - HasTendon
 
 - type: entity
   parent: [ OrganBaseLegLeft, OrganHumanExternal ]
   id: OrganHumanLegLeft
+  components:
+  - type: ExternalOrgan
+    maxDamage: 80
+    minBrokenDamage: 50
+    flags:
+    - CanAmputate
+    - CanBreak
+    - CanStand
+    - HasTendon
 
 - type: entity
   parent: [ OrganBaseLegRight, OrganHumanExternal ]
   id: OrganHumanLegRight
+  components:
+  - type: ExternalOrgan
+    maxDamage: 80
+    minBrokenDamage: 50
+    flags:
+    - CanAmputate
+    - CanBreak
+    - CanStand
+    - HasTendon
 
 - type: entity
   parent: [ OrganBaseFootLeft, OrganHumanExternal ]
   id: OrganHumanFootLeft
+  components:
+  - type: ExternalOrgan
+    maxDamage: 50
+    minBrokenDamage: 30
+    flags:
+    - CanAmputate
+    - CanBreak
+    - CanStand
+    - HasTendon
 
 - type: entity
   parent: [ OrganBaseFootRight, OrganHumanExternal ]
   id: OrganHumanFootRight
+  components:
+  - type: ExternalOrgan
+    maxDamage: 50
+    minBrokenDamage: 30
+    flags:
+    - CanAmputate
+    - CanBreak
+    - CanStand
+    - HasTendon
 
 - type: entity
   parent: [ OrganBaseBrain, OrganHumanInternal ]
@@ -205,10 +294,17 @@
 - type: entity
   parent: [ OrganBaseLungs, OrganHumanInternal, OrganHumanMetabolizer ]
   id: OrganHumanLungs
+  components:
+  - type: LungCondition
+    efficiency: 1.0
 
 - type: entity
   parent: [ OrganBaseHeart, OrganHumanInternal, OrganHumanMetabolizer ]
   id: OrganHumanHeart
+  components:
+  - type: HeartCondition
+    efficiency: 1.0
+    beating: true
 
 - type: entity
   parent: [ OrganBaseStomach, OrganHumanInternal, OrganHumanMetabolizer ]
@@ -221,3 +317,4 @@
 - type: entity
   parent: [ OrganBaseKidneys, OrganHumanInternal, OrganHumanMetabolizer ]
   id: OrganHumanKidneys
+# Baystation end

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -1,3 +1,4 @@
+# Baystation start
 - type: markingsGroup
   id: None
   onlyGroupWhitelisted: true
@@ -498,3 +499,4 @@
     sexStateOverrides:
       Male: torso_m
       Female: torso_f
+# Baystation end

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -1,3 +1,4 @@
+# Baystation start
 - type: entity
   abstract: true
   parent:
@@ -151,6 +152,15 @@
     deathPenalty: 0.01 # However they really ought to be living and intact, otherwise they're worth 100x less.
   - type: RandomPrice
     maxRandomPrice: 20000
+  - type: WoundCapacity
+    defaultCapacity: 3
+    groupCapacity:
+      Brute: 3
+      Burn: 3
+      Cut: 3
+      Puncture: 3
+      Stump: 3
+      Incision: 3
   - type: Tag
     tags:
     - CanPilot
@@ -230,3 +240,4 @@
   - type: ESPainFlash # Funky, ES port
   - type: FootprintOwner # Funky change
   - type: DuoEmote # Funky change
+# Baystation end

--- a/Resources/Prototypes/Medical/wound_effects.yml
+++ b/Resources/Prototypes/Medical/wound_effects.yml
@@ -1,0 +1,309 @@
+# Baystation start
+# Wound effect prototypes for the entity-based wound system.
+# Each effect defines a behavior type and its default config values.
+# Wound entities reference these by ID in their WoundEffects component.
+
+# --- Bleeding effects (baseBleedAmount, bleedTimer: ticks until natural stop) ---
+
+- type: woundEffect
+  id: BleedingTiny
+  effectType: Bleeding
+  config:
+    baseBleedAmount: 0.5
+    bleedTimer: 30
+
+- type: woundEffect
+  id: BleedingSmall
+  effectType: Bleeding
+  config:
+    baseBleedAmount: 1.0
+    bleedTimer: 45
+
+- type: woundEffect
+  id: BleedingLight
+  effectType: Bleeding
+  config:
+    baseBleedAmount: 1.5
+    bleedTimer: 60
+
+- type: woundEffect
+  id: BleedingModerate
+  effectType: Bleeding
+  config:
+    baseBleedAmount: 2.0
+    bleedTimer: 75
+
+- type: woundEffect
+  id: BleedingFair
+  effectType: Bleeding
+  config:
+    baseBleedAmount: 2.5
+    bleedTimer: 90
+
+- type: woundEffect
+  id: BleedingLarge
+  effectType: Bleeding
+  config:
+    baseBleedAmount: 3.0
+    bleedTimer: 105
+
+- type: woundEffect
+  id: BleedingHeavy
+  effectType: Bleeding
+  config:
+    baseBleedAmount: 4.0
+    bleedTimer: 120
+
+- type: woundEffect
+  id: BleedingSevere
+  effectType: Bleeding
+  config:
+    baseBleedAmount: 5.0
+    bleedTimer: 150
+
+- type: woundEffect
+  id: BleedingCritical
+  effectType: Bleeding
+  config:
+    baseBleedAmount: 6.0
+    bleedTimer: 180
+
+- type: woundEffect
+  id: BleedingMassive
+  effectType: Bleeding
+  config:
+    baseBleedAmount: 8.0
+    bleedTimer: 240
+
+# --- Pain effects (painAmount, freshPainAmount) ---
+
+- type: woundEffect
+  id: PainMinute
+  effectType: Pain
+  config:
+    painAmount: 0.5
+    freshPainAmount: 1.0
+
+- type: woundEffect
+  id: PainMild
+  effectType: Pain
+  config:
+    painAmount: 1.0
+    freshPainAmount: 3.0
+
+- type: woundEffect
+  id: PainUncomfortable
+  effectType: Pain
+  config:
+    painAmount: 2.0
+    freshPainAmount: 5.0
+
+- type: woundEffect
+  id: PainModerate
+  effectType: Pain
+  config:
+    painAmount: 3.0
+    freshPainAmount: 8.0
+
+- type: woundEffect
+  id: PainBothersome
+  effectType: Pain
+  config:
+    painAmount: 4.0
+    freshPainAmount: 10.0
+
+- type: woundEffect
+  id: PainNasty
+  effectType: Pain
+  config:
+    painAmount: 5.0
+    freshPainAmount: 12.0
+
+- type: woundEffect
+  id: PainPainful
+  effectType: Pain
+  config:
+    painAmount: 6.0
+    freshPainAmount: 14.0
+
+- type: woundEffect
+  id: PainSevere
+  effectType: Pain
+  config:
+    painAmount: 8.0
+    freshPainAmount: 18.0
+
+- type: woundEffect
+  id: PainAgonizing
+  effectType: Pain
+  config:
+    painAmount: 10.0
+    freshPainAmount: 22.0
+
+- type: woundEffect
+  id: PainExcruciating
+  effectType: Pain
+  config:
+    painAmount: 12.0
+    freshPainAmount: 25.0
+
+- type: woundEffect
+  id: PainUnbearable
+  effectType: Pain
+  config:
+    painAmount: 14.0
+    freshPainAmount: 28.0
+
+- type: woundEffect
+  id: PainHellish
+  effectType: Pain
+  config:
+    painAmount: 15.0
+    freshPainAmount: 30.0
+
+- type: woundEffect
+  id: PainTorment
+  effectType: Pain
+  config:
+    painAmount: 18.0
+    freshPainAmount: 35.0
+
+- type: woundEffect
+  id: PainMortal
+  effectType: Pain
+  config:
+    painAmount: 20.0
+    freshPainAmount: 40.0
+
+- type: woundEffect
+  id: PainCutDeep
+  effectType: Pain
+  config:
+    painAmount: 4.0
+    freshPainAmount: 8.0
+
+- type: woundEffect
+  id: PainPunctureSmall
+  effectType: Pain
+  config:
+    painAmount: 3.0
+    freshPainAmount: 7.0
+
+- type: woundEffect
+  id: PainSurgical
+  effectType: Pain
+  config:
+    painAmount: 1.0
+    freshPainAmount: 2.0
+
+# --- Healable effects (healPerTick, autohealCutoff: max damage that can heal without treatment) ---
+
+- type: woundEffect
+  id: HealableVeryFast
+  effectType: Healable
+  config:
+    healPerTick: 0.15
+    autohealCutoff: 5
+
+- type: woundEffect
+  id: HealableFast
+  effectType: Healable
+  config:
+    healPerTick: 0.1
+    autohealCutoff: 10
+
+- type: woundEffect
+  id: HealableMedium
+  effectType: Healable
+  config:
+    healPerTick: 0.08
+    autohealCutoff: 15
+
+- type: woundEffect
+  id: HealableModerate
+  effectType: Healable
+  config:
+    healPerTick: 0.06
+    autohealCutoff: 20
+
+- type: woundEffect
+  id: HealableSlow
+  effectType: Healable
+  config:
+    healPerTick: 0.05
+    autohealCutoff: 25
+
+- type: woundEffect
+  id: HealableVerySlow
+  effectType: Healable
+  config:
+    healPerTick: 0.04
+    autohealCutoff: 30
+
+- type: woundEffect
+  id: HealableExtremelySlow
+  effectType: Healable
+  config:
+    healPerTick: 0.03
+    autohealCutoff: 50
+
+- type: woundEffect
+  id: HealableGlacial
+  effectType: Healable
+  config:
+    healPerTick: 0.02
+    autohealCutoff: 60
+
+- type: woundEffect
+  id: HealableMolasses
+  effectType: Healable
+  config:
+    healPerTick: 0.015
+    autohealCutoff: 80
+
+- type: woundEffect
+  id: HealableGlacialest
+  effectType: Healable
+  config:
+    healPerTick: 0.01
+    autohealCutoff: 100
+
+- type: woundEffect
+  id: HealableNone
+  effectType: Healable
+  config:
+    healPerTick: 0
+    autohealCutoff: 0
+
+# --- Marker effects ---
+
+- type: woundEffect
+  id: Tendable
+  effectType: Tendable
+  config: {}
+
+- type: woundEffect
+  id: Clampable
+  effectType: Clampable
+  config: {}
+
+- type: woundEffect
+  id: Salvable
+  effectType: Salvable
+  config: {}
+
+- type: woundEffect
+  id: GermTracking
+  effectType: Germ
+  config: {}
+
+- type: woundEffect
+  id: Surgical
+  effectType: Surgical
+  config: {}
+
+- type: woundEffect
+  id: Embedded
+  effectType: Embedded
+  config: {}
+# Baystation end

--- a/Resources/Prototypes/Medical/wounds.yml
+++ b/Resources/Prototypes/Medical/wounds.yml
@@ -1,0 +1,520 @@
+# Baystation start
+# Entity-based wound prototypes for the Baystation medical system.
+# Each wound is a full entity with a WoundEffects component
+# that references YAML-defined effect prototypes.
+
+# --- Base wound entity ---
+
+- type: entity
+  id: WoundBase
+  abstract: true
+  description: A wound.
+  components:
+  - type: Wound
+    maximumDamage: 100
+  - type: WoundEffects
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-tiny
+      10.0: wound-small
+      20.0: wound-moderate
+      40.0: wound-large
+      60.0: wound-severe
+
+# --- Brute / Bruise wounds ---
+
+- type: entity
+  parent: WoundBase
+  id: WoundBruteTiny
+  name: tiny bruise
+  description: A barely visible bruise.
+  components:
+  - type: Wound
+    maximumDamage: 5
+    group: Brute
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-brute-tiny
+  - type: WoundEffects
+    effects:
+    - id: PainMinute
+    - id: HealableVeryFast
+    - id: GermTracking
+
+- type: entity
+  parent: WoundBase
+  id: WoundBruteSmall
+  name: small bruise
+  description: A minor bruise.
+  components:
+  - type: Wound
+    maximumDamage: 10
+    group: Brute
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-brute-small
+  - type: WoundEffects
+    effects:
+    - id: BleedingTiny
+    - id: Tendable
+    - id: HealableFast
+    - id: PainMild
+    - id: GermTracking
+
+- type: entity
+  parent: WoundBase
+  id: WoundBruteModerate
+  name: moderate bruise
+  description: A clear bruise.
+  components:
+  - type: Wound
+    maximumDamage: 20
+    group: Brute
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-brute-moderate
+  - type: WoundEffects
+    effects:
+    - id: BleedingLight
+    - id: Tendable
+    - id: Clampable
+    - id: HealableMedium
+    - id: PainModerate
+    - id: GermTracking
+
+- type: entity
+  parent: WoundBase
+  id: WoundBruteLarge
+  name: large bruise
+  description: A large, dark bruise with swelling.
+  components:
+  - type: Wound
+    maximumDamage: 30
+    group: Brute
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-brute-large
+  - type: WoundEffects
+    effects:
+    - id: BleedingFair
+    - id: Tendable
+    - id: Clampable
+    - id: HealableSlow
+    - id: PainNasty
+    - id: GermTracking
+
+- type: entity
+  parent: WoundBase
+  id: WoundBruteHuge
+  name: huge bruise
+  description: A massive bruise covering a large area.
+  components:
+  - type: Wound
+    maximumDamage: 50
+    group: Brute
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-brute-huge
+  - type: WoundEffects
+    effects:
+    - id: BleedingHeavy
+    - id: Tendable
+    - id: Clampable
+    - id: HealableExtremelySlow
+    - id: PainSevere
+    - id: GermTracking
+
+- type: entity
+  parent: WoundBase
+  id: WoundBruteMonumental
+  name: monumental bruise
+  description: An enormous, devastating bruise.
+  components:
+  - type: Wound
+    maximumDamage: 80
+    group: Brute
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-brute-monumental
+  - type: WoundEffects
+    effects:
+    - id: BleedingCritical
+    - id: Tendable
+    - id: Clampable
+    - id: HealableGlacialest
+    - id: PainHellish
+    - id: GermTracking
+
+# --- Burn wounds ---
+
+- type: entity
+  parent: WoundBase
+  id: WoundBurnSmall
+  name: minor burn
+  description: A small burn or scald.
+  components:
+  - type: Wound
+    maximumDamage: 10
+    group: Burn
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-burn-small
+  - type: WoundEffects
+    effects:
+    - id: HealableFast
+    - id: PainUncomfortable
+    - id: GermTracking
+    - id: Salvable
+
+- type: entity
+  parent: WoundBase
+  id: WoundBurnModerate
+  name: moderate burn
+  description: A clear burn with blistering.
+  components:
+  - type: Wound
+    maximumDamage: 15
+    group: Burn
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-burn-moderate
+  - type: WoundEffects
+    effects:
+    - id: HealableMedium
+    - id: PainBothersome
+    - id: GermTracking
+    - id: Salvable
+
+- type: entity
+  parent: WoundBase
+  id: WoundBurnLarge
+  name: large burn
+  description: A large burn with charred edges.
+  components:
+  - type: Wound
+    maximumDamage: 30
+    group: Burn
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-burn-large
+  - type: WoundEffects
+    effects:
+    - id: HealableSlow
+    - id: PainPainful
+    - id: GermTracking
+    - id: Salvable
+
+- type: entity
+  parent: WoundBase
+  id: WoundBurnSevere
+  name: severe burn
+  description: A severe burn with extensive tissue damage.
+  components:
+  - type: Wound
+    maximumDamage: 40
+    group: Burn
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-burn-severe
+  - type: WoundEffects
+    effects:
+    - id: HealableExtremelySlow
+    - id: PainAgonizing
+    - id: GermTracking
+    - id: Salvable
+
+- type: entity
+  parent: WoundBase
+  id: WoundBurnDeep
+  name: deep burn
+  description: A deep burn reaching underlying tissue.
+  components:
+  - type: Wound
+    maximumDamage: 50
+    group: Burn
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-burn-deep
+  - type: WoundEffects
+    effects:
+    - id: HealableGlacial
+    - id: PainUnbearable
+    - id: GermTracking
+    - id: Salvable
+
+- type: entity
+  parent: WoundBase
+  id: WoundBurnCarbonised
+  name: carbonised burn
+  description: A deep burn with carbonised flesh.
+  components:
+  - type: Wound
+    maximumDamage: 80
+    group: Burn
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-burn-carbonised
+  - type: WoundEffects
+    effects:
+    - id: HealableGlacialest
+    - id: PainMortal
+    - id: GermTracking
+    - id: Salvable
+
+# --- Cut wounds ---
+
+- type: entity
+  parent: WoundBase
+  id: WoundCutSmall
+  name: small cut
+  description: A small cut on the skin.
+  components:
+  - type: Wound
+    maximumDamage: 10
+    group: Cut
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-cut-small
+  - type: WoundEffects
+    effects:
+    - id: BleedingSmall
+    - id: Tendable
+    - id: HealableMedium
+    - id: PainUncomfortable
+    - id: GermTracking
+
+- type: entity
+  parent: WoundBase
+  id: WoundCutDeep
+  name: deep cut
+  description: A deep cut reaching into the flesh.
+  components:
+  - type: Wound
+    maximumDamage: 15
+    group: Cut
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-cut-deep
+  - type: WoundEffects
+    effects:
+    - id: BleedingModerate
+    - id: Tendable
+    - id: Clampable
+    - id: HealableModerate
+    - id: PainCutDeep
+    - id: GermTracking
+
+- type: entity
+  parent: WoundBase
+  id: WoundCutFlesh
+  name: flesh wound
+  description: A wound cutting into the flesh.
+  components:
+  - type: Wound
+    maximumDamage: 25
+    group: Cut
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-cut-flesh
+  - type: WoundEffects
+    effects:
+    - id: BleedingLarge
+    - id: Tendable
+    - id: Clampable
+    - id: HealableVerySlow
+    - id: PainPainful
+    - id: GermTracking
+
+- type: entity
+  parent: WoundBase
+  id: WoundCutGaping
+  name: gaping wound
+  description: A wide, gaping wound.
+  components:
+  - type: Wound
+    maximumDamage: 50
+    group: Cut
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-cut-gaping
+  - type: WoundEffects
+    effects:
+    - id: BleedingSevere
+    - id: Tendable
+    - id: Clampable
+    - id: HealableExtremelySlow
+    - id: PainAgonizing
+    - id: GermTracking
+
+- type: entity
+  parent: WoundBase
+  id: WoundCutMassive
+  name: massive wound
+  description: A massive, devastating wound.
+  components:
+  - type: Wound
+    maximumDamage: 80
+    group: Cut
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-cut-massive
+  - type: WoundEffects
+    effects:
+    - id: BleedingMassive
+    - id: Tendable
+    - id: Clampable
+    - id: HealableGlacialest
+    - id: PainTorment
+    - id: GermTracking
+
+# --- Puncture wounds ---
+
+- type: entity
+  parent: WoundBase
+  id: WoundPunctureSmall
+  name: small puncture
+  description: A small puncture wound.
+  components:
+  - type: Wound
+    maximumDamage: 10
+    group: Puncture
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-puncture-small
+  - type: WoundEffects
+    effects:
+    - id: BleedingLight
+    - id: Clampable
+    - id: HealableModerate
+    - id: PainPunctureSmall
+    - id: GermTracking
+
+- type: entity
+  parent: WoundBase
+  id: WoundPunctureFlesh
+  name: puncture wound
+  description: A puncture wound into the flesh.
+  components:
+  - type: Wound
+    maximumDamage: 15
+    group: Puncture
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-puncture-flesh
+  - type: WoundEffects
+    effects:
+    - id: BleedingFair
+    - id: Clampable
+    - id: HealableVerySlow
+    - id: PainNasty
+    - id: GermTracking
+
+- type: entity
+  parent: WoundBase
+  id: WoundPunctureGaping
+  name: gaping puncture
+  description: A gaping puncture hole.
+  components:
+  - type: Wound
+    maximumDamage: 30
+    group: Puncture
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-puncture-gaping
+  - type: WoundEffects
+    effects:
+    - id: BleedingHeavy
+    - id: Clampable
+    - id: HealableExtremelySlow
+    - id: PainSevere
+    - id: GermTracking
+
+- type: entity
+  parent: WoundBase
+  id: WoundPunctureMassive
+  name: massive puncture
+  description: A massive penetrating wound.
+  components:
+  - type: Wound
+    maximumDamage: 60
+    group: Puncture
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-puncture-massive
+  - type: WoundEffects
+    effects:
+    - id: BleedingCritical
+    - id: Clampable
+    - id: HealableMolasses
+    - id: PainUnbearable
+    - id: GermTracking
+
+# --- Lost limb / Stump wounds ---
+
+- type: entity
+  parent: WoundBase
+  id: WoundStumpEdge
+  name: ripped stump
+  description: A bloody stump where a limb was torn off.
+  components:
+  - type: Wound
+    maximumDamage: 80
+    group: Stump
+    isSurgical: true
+    healPerTick: 0
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-stump-edge
+  - type: WoundEffects
+    effects:
+    - id: BleedingLarge
+    - id: Tendable
+    - id: HealableNone
+    - id: PainHellish
+    - id: GermTracking
+    - id: Surgical
+
+- type: entity
+  parent: WoundBase
+  id: WoundStumpBurn
+  name: charred stump
+  description: A charred stump where a limb was burned off.
+  components:
+  - type: Wound
+    maximumDamage: 80
+    group: Stump
+    isSurgical: true
+    healPerTick: 0
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-stump-burn
+  - type: WoundEffects
+    effects:
+    - id: HealableNone
+    - id: PainExcruciating
+    - id: GermTracking
+    - id: Surgical
+
+# --- Surgical incision (does not heal naturally) ---
+
+- type: entity
+  parent: WoundBase
+  id: WoundSurgicalIncision
+  name: surgical incision
+  description: A clean surgical incision.
+  components:
+  - type: Wound
+    maximumDamage: 10
+    group: Incision
+    isSurgical: true
+    healPerTick: 0
+  - type: WoundDescription
+    descriptions:
+      0.0: wound-incision
+  - type: WoundEffects
+    effects:
+    - id: HealableNone
+    - id: PainSurgical
+    - id: GermTracking
+    - id: Surgical
+# Baystation end

--- a/Resources/Prototypes/Reagents/sterilizine.yml
+++ b/Resources/Prototypes/Reagents/sterilizine.yml
@@ -1,0 +1,17 @@
+# Baystation start
+- type: reagent
+  id: Sterilizine
+  name: reagent-name-sterilizine
+  group: Medicine
+  desc: reagent-desc-sterilizine
+  physicalDesc: reagent-physical-desc-translucent
+  flavor: medicine
+  color: "#c8e6c9"
+  metabolisms:
+    Bloodstream:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: -0.5
+# Baystation end


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
Ports the Baystation 12 wound system over to SS14. This replaces the old basic damage numbers with wounds! Wounds are now full entities with configurable effects for bleeding, pain, healing, infection, and embedded objects. Also adds limb-targeted damage distribution (melee hits a random limb, explosions distribute across all limbs), a basic pain/shock system, and supporting medical infrastructure.

## Why / Balance
The old system was boring as hell, it was just tracking damages, and you healed that by using chemicals and topicals. BOOORING!!! Wounds make is somewhat more interesting!

## Technical details
### Wound System
- `WoundEffectPrototype` — new `[Prototype("woundEffect")]` data prototype with `EffectType` discriminator and `Config` dictionary
- `WoundEffectsComponent` — generic runtime container holding `List<WoundEffectInstance>`, each with `FloatParams` (runtime state) and `StringListParams` (embedded items)
- 55 effect prototypes in `wound_effects.yml` covering bleeding, pain, healable, tendable, clampable, salvable, germ tracking, surgical, and embedded behaviors
- 24 wound entity prototypes in `wounds.yml` (Brute, Burn, Cut, Puncture, Stump, Incision tiers)
- `WoundCapacityComponent` — per-species/organ capacity limits (3 per damage group)
- `WoundTypeOverrideComponent` — weapon-specific wound type overrides
- Wound worsening — existing wounds widen up to 1.5× their max damage before creating new ones
- Bleed timer — wounds naturally stop bleeding over time.
- Autoheal cutoff — wounds above a damage threshold won't heal without treatment
- Probabilistic infection — infection chance varies by wound type (burns 25%, cuts 10%, bruises 5%)
- Disinfection — sterilizine sets `disinfected = 1`, preventing future infection
- Fluid loss from burns — severe burns cause proportional blood loss
- Burn re-opening — blunt damage can disturb salved burns
- Stage descriptions — wound stage texts shown on examine

### Limb Damage Distribution
- `LimbDamageSystem` — intercepts melee/projectile/hitscan damage before `DamageableSystem`, distributes to a random limb via `ExternalOrganComponent`
- Untargeted damage (explosions, fire) split evenly across all limbs
- Fracture checks when brute damage exceeds `MinBrokenDamage`

### Pain System
- Per-limb pain tracking via `WoundableComponent.Pain`
- Contextual pain messages per body part with three severity tiers
- Painkiller suppression from bloodstream chemicals (Paracetamol, Tramadol, Oxycodone)
- Anti-spam cooldown for pain messages
- Pain drop item and stun events at high thresholds

### Supporting Infrastructure
- `BloodOxygenationComponent/System` — oxygen saturation and pulse rate tracking
- `HeartConditionComponent`, `LungConditionComponent` — vital organ condition tracking
- `BrainSystem.BrainDamage.cs` — brain integrity damage/healing
- `CPRSystem` — CPR mechanics
- `SterilizineComponent/System` — wound disinfection
- `HealthAnalyzerSystem` — medical scanner with wound inspection
- `MedicalDebugCommand` — admin command `medicaldebug <entity>` for debugging limb/wound state
- `LimbEvents.cs` — fracture, dismemberment, and amputation events

## Test plan
1. Attack a humanoid and observe wounds appearing on the targeted limb
2. Check bleeding, pain, and healing match expected values from YAML configs
3. Verify wound merging (multiple hits to same limb combine wounds)
4. Test wound worsening (hitting an existing wound widens it instead of creating new)
5. Apply bandages and verify bleeding reduction
6. Apply sterilizine and verify disinfection flag prevents infection
7. Let infection build on an untreated wound and observe toxin damage
8. Use `medicaldebug <entity>` to inspect limb damage and wound state
9. Test health analyzer on a damaged player
10. Admin logs show surgery and wound events

## Media
N/A

## Requirements
- [X] I have read and am following the Macrocosm Pull Request Conventions.
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [ ] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.

## License
MIT

## Breaking changes
Pretty much every file that it touches breaks something else.

## Changelog
:cl:
- add: Wound system with customizable wounds, effects, and management methods.
- add: New Health Analyser display that shows the parameters that affect your health!
- add: Basic pain system, will be fleshed out in later PRs!
