### PR TITLE
Github workflow change

### DIFF
--- a/.github/workflows/labeler-review.yml
+++ b/.github/workflows/labeler-review.yml
@@ -1,16 +1,38 @@
-name: "Labels: Approved"
+name: "Labels: Remove statuses on close"
 on:
-  pull_request_review:
-    types: [submitted]
+  pull_request_target:
+    types: [closed]
 jobs:
   add_label:
     # Change the repository name after you've made sure the team name is correct for your fork!
-    if: ${{ (github.repository == 'funky-station/forky-station') && (github.event.review.state == 'APPROVED') }}
-    permissions:
-      contents: read
-      pull-requests: write
+    if: ${{ (github.repository == 'funky-station/forky-station') }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions-ecosystem/action-add-labels@v1
-      with:
-        labels: "Status: Approved"
+    - if: ${{contains(github.event.pull_request.labels.*.name, format('Status{0} Untriaged', ':'))}}
+      run: |
+        curl --silent --fail-with-body \
+        -X DELETE \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: token ${{ github.token }}" \
+        https://api.github.com/repos/${{github.repository}}/issues/${{github.event.number}}/labels/Status%3A%20Untriaged
+    - if: ${{ contains(github.event.pull_request.labels.*.name, format('Status{0} Merge Conflict', ':'))}}
+      run: |
+        curl --silent --fail-with-body \
+        -X DELETE \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: token ${{ github.token }}" \
+        https://api.github.com/repos/${{github.repository}}/issues/${{github.event.number}}/labels/Status%3A%20Merge%20Conflict
+    - if: ${{ contains(github.event.pull_request.labels.*.name, format('Status{0} Needs Review', ':'))}}
+      run: |
+        curl --silent --fail-with-body \
+        -X DELETE \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: token ${{ github.token}}" \
+        https://api.github.com/repos/${{ github.repository }}/issues/${{github.event.number}}/labels/Status%3A%20Needs%20Review
+    - if: ${{ contains(github.event.pull_request.labels.*.name, format('Status{0} Awaiting Changes', ':'))}}
+      run: |
+        curl --silent --fail-with-body \
+        -X DELETE \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: token ${{ github.token}}" \
+        https://api.github.com/repos/${{ github.repository }}/issues/${{github.event.number}}/labels/Status%3A%20Awaiting%20Changes


### PR DESCRIPTION
## About the PR

Edits the "approval" workflow whose function is basically impossible currently to just remove certain development triage labels when a PR is merged

## Why / Balance
Prevents workflow fails because the workflow cannot fail

## Technical details
It uses cURL with the github recommended API calls because i like cURL and reduces reliance on external code

## Test plan

This PR was tested on my local repository (with the changed repo name) and worked perfectly fine in all the test cases

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes

This should not break anything.
If a downstream repo wants to utilize this function, they must use our labels with the same label names and change the (comment-prompted) repo name in the workflow to theirs.

## Changelog

As this is not a player-facing change the changelog bot shouldn't scrub this PR.
