### PR TITLE
Job restructuring, part 1

### DIFF
--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -39,6 +39,7 @@ public sealed partial class IdCardConsoleComponent : Component
 
     // Put this on shared so we just send the state once in PVS range rather than every time the UI updates.
     // TODO: Move these to the YAML prototype or something because holy shit
+    // edited to include funky accesses
     [DataField, AutoNetworkedField]
     public List<ProtoId<AccessLevelPrototype>> AccessLevels = new()
     {
@@ -54,17 +55,22 @@ public sealed partial class IdCardConsoleComponent : Component
         "ChiefEngineer",
         "ChiefMedicalOfficer",
         "Command",
+        "Corporate",
         "Cryogenics",
         "Engineering",
+        "ExecutiveOfficer",
         "External",
         "GenpopEnter",
         "GenpopLeave",
-        "HeadOfPersonnel",
         "HeadOfSecurity",
+        "HospitalityDirector",
         "Hydroponics",
+        "InternalAffairs",
         "Janitor",
         "Kitchen",
         "Lawyer",
+        "Library",
+        "Magistrate",
         "Maintenance",
         "Medical",
         "Newsroom",

--- a/Resources/Locale/en-US/_Funkystation/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/_Funkystation/headset/headset-component.ftl
@@ -1,1 +1,2 @@
 chat-radio-logistics = Logistics
+chat-radio-ia = Internal Affairs

--- a/Resources/Locale/en-US/_Funkystation/job/department-desc.ftl
+++ b/Resources/Locale/en-US/_Funkystation/job/department-desc.ftl
@@ -1,2 +1,3 @@
 department-Logistics-description = Produce raw materials, purchase goods, and distribute them across the station.
 department-Service-description = Keep crew morale high by providing catering and entertainment.
+department-InternalAffairs-description = Audit departments for SOP breaches and handle legal proceedings.

--- a/Resources/Locale/en-US/_Funkystation/job/department.ftl
+++ b/Resources/Locale/en-US/_Funkystation/job/department.ftl
@@ -1,2 +1,3 @@
 department-Logistics = Logistics
 department-Service = Service
+department-InternalAffairs = Internal Affairs

--- a/Resources/Locale/en-US/_Funkystation/job/job-description.ftl
+++ b/Resources/Locale/en-US/_Funkystation/job/job-description.ftl
@@ -1,1 +1,6 @@
 job-description-assistant = Assist the station's crew as one of its more expendable assets.
+job-description-xo = Manage station staff, handle job transfers, and process audit reports.
+job-description-magistrate = Handle sentencing on detained crew, and preside over judicial hearings.
+job-description-iaa = Audit station departments for breaches of Standard Operating Procedure.
+job-description-hd = Ensure the station's catering and entertainment runs smoothly, and coordinate events.
+job-description-cl = Advise the heads of staff on company policy and expected procedure.

--- a/Resources/Locale/en-US/_Funkystation/job/job-supervisors.ftl
+++ b/Resources/Locale/en-US/_Funkystation/job/job-supervisors.ftl
@@ -1,1 +1,3 @@
 job-supervisors-audience = your audience
+job-supervisors-ia = the Executive Officer
+job-supervisors-cl = Central Command, although you are here in an exclusively advisory capacity

--- a/Resources/Locale/en-US/_Funkystation/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/_Funkystation/prototypes/access/accesses.ftl
@@ -1,1 +1,10 @@
 id-card-access-level-newsroom = Newsroom
+
+id-card-access-level-ia = Internal Affairs
+id-card-access-level-magistrate = Magistrate
+id-card-access-level-xo = Executive Officer
+
+id-card-access-level-cl = Corporate
+
+id-card-access-level-hd = Hospitality Director
+id-card-access-level-library = Library

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -3,7 +3,7 @@
   tags:
   - EmergencyShuttleRepealAll
   - Captain
-  - HeadOfPersonnel
+#  - HeadOfPersonnel - funky
   - ChiefEngineer
   - ChiefMedicalOfficer
   - HeadOfSecurity
@@ -35,6 +35,12 @@
   - GenpopEnter
   - GenpopLeave
   - Newsroom # Funky
+  - Library # funky
+  - Corporate # funky
+  - InternalAffairs #funky
+  - Magistrate #funky
+  - HospitalityDirector #funky
+  - ExecutiveOfficer #funky
 
 - type: accessGroup
   id: General

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -78,6 +78,7 @@
     - Security
     - Service
     - Supply
+    - InternalAffairs #funky
     defaultChannel: Command
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -19,7 +19,6 @@
           availableJobs: # 60 jobs total w/o latejoins & interns, 77 jobs total w/ latejoins & interns
             #command (7)
             Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
@@ -35,7 +34,6 @@
             ServiceWorker: [ 2, 2 ]
             Reporter: [ 2, 2 ]
             #engineering (7)
-            AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 4, 4 ]
             TechnicalAssistant: [ 4, 4 ] #intern, not counted
             #medical (6)
@@ -53,7 +51,6 @@
             SecurityCadet: [ 4, 4 ] #intern, not counted
             Lawyer: [ 2, 2 ]
             #supply (6)
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian (3+)
             Passenger: [ -1, -1 ] #infinite, not counted
@@ -61,5 +58,4 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             #silicon (3)
-            StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -18,7 +18,6 @@
           availableJobs: # 63 jobs total w/o latejoins & interns, 82 jobs total w/ latejoins & interns
             #Command (7)
             Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
@@ -34,7 +33,6 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
             #Engineering (8)
-            AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 5, 5 ]
             TechnicalAssistant: [ 4, 4 ] #intern, exclude from dept count
             #Medical (8)
@@ -53,7 +51,6 @@
             SecurityCadet: [ 2, 4 ] #intern, exclude from dept count
             Lawyer: [ 2, 2 ]
             #Supply (6)
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #Civilian (3+)
             Passenger: [ -1, -1 ] #infinite, not counted
@@ -61,5 +58,4 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             #Silicon (3)
-            StationAi: [ 1, 1 ]
             Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Maps/elkridge.yml
+++ b/Resources/Prototypes/Maps/elkridge.yml
@@ -21,7 +21,6 @@
           availableJobs: # 46 jobs total w/o latejoins & interns, 61 jobs total w/ latejoins & interns
             #command (7)
             Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
@@ -37,7 +36,6 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
             #engineering (5 - 6)
-            AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 3, 4 ]
             TechnicalAssistant: [ 2, 2 ] #intern, not counted
             #medical (6 - 7)
@@ -56,7 +54,6 @@
             SecurityCadet: [ 2, 2 ] #intern, not counted
             Lawyer: [ 1, 1 ]
             #supply (4 - 5)
-            SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 3 ]
             #civilian (3+)
             Passenger: [ -1, -1 ] #infinite, not counted
@@ -64,5 +61,4 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             #silicon (3)
-            StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/exo.yml
+++ b/Resources/Prototypes/Maps/exo.yml
@@ -21,7 +21,6 @@
           availableJobs:
             #service
             Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 2 ]
             Chef: [ 2, 2 ]
@@ -31,7 +30,6 @@
             ServiceWorker: [ 2, 2 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 4, 4 ]
             TechnicalAssistant: [ 3, 3 ]
             #medical
@@ -54,7 +52,6 @@
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
             Passenger: [ -1, -1 ]
@@ -63,5 +60,4 @@
             Musician: [ 1, 1 ]
             Reporter: [ 2, 2 ]
             #silicon
-            StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -20,7 +20,6 @@
           availableJobs: # 81 jobs total w/o latejoins & interns, 101 jobs total w/ latejoins & interns
             #command (7)
             Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
@@ -36,7 +35,6 @@
             ServiceWorker: [ 2, 2 ]
             Reporter: [ 2, 2 ]
             #engineering (9)
-            AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 6, 6 ]
             TechnicalAssistant: [ 4, 4 ] #intern, not counted
             #medical (11)
@@ -54,7 +52,6 @@
             SecurityCadet: [ 6, 6 ] #intern, not counted
             Lawyer: [ 2, 2 ]
             #supply (9)
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 6, 6 ]
             #civilian (3+)
             Passenger: [ -1, -1 ] #infinite, not counted
@@ -62,5 +59,4 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             #silicon (6)
-            StationAi: [ 1, 1 ]
             Borg: [ 5, 5 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -34,7 +34,6 @@
             Librarian: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
             #engineering (7)
-            AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 4, 4 ]
             TechnicalAssistant: [ 3, 3 ] #intern, not counted
             #medical (8)
@@ -53,7 +52,6 @@
             SecurityCadet: [ 4, 4 ] #intern, not counted
             Lawyer: [ 2, 2 ]
             #supply (6)
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian (3+)
             Passenger: [ -1, -1 ] #infinite, not counted
@@ -61,5 +59,4 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             #silicon (3)
-            StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -18,7 +18,6 @@
           availableJobs: # 72 jobs total w/o latejoins & interns, 91 jobs total w/ latejoins & interns
             #command (7)
             Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
@@ -34,7 +33,6 @@
             ServiceWorker: [ 2, 2 ]
             Reporter: [ 1, 1 ]
             #engineering (8)
-            AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 5, 5 ]
             TechnicalAssistant: [ 4, 4 ] #intern, not counted
             #medical (11)
@@ -53,7 +51,6 @@
             SecurityCadet: [ 4, 4 ] #intern, not counted
             Lawyer: [ 3, 3 ]
             #supply (7)
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian (3+)
             Passenger: [ -1, -1 ] #infinite, not counted
@@ -62,4 +59,3 @@
             Musician: [ 1, 1 ]
             #silicon (3)
             Borg: [ 2, 2 ]
-            StationAi: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -19,7 +19,6 @@
         availableJobs: # 47 jobs total w/o latejoins & interns, 58 jobs total w/ latejoins & interns
           #command (7)
           Captain: [ 1, 1 ]
-          HeadOfPersonnel: [ 1, 1 ]
           HeadOfSecurity: [ 1, 1 ]
           ChiefMedicalOfficer: [ 1, 1 ]
           ChiefEngineer: [ 1, 1 ]
@@ -34,7 +33,6 @@
           Librarian: [ 1, 1 ]
           ServiceWorker: [ 2, 2 ]
           #engineering (6)
-          AtmosphericTechnician: [ 2, 2 ]
           StationEngineer: [ 4, 4 ]
           TechnicalAssistant: [ 3, 3 ] #intern, not counted
           #medical (6)
@@ -52,7 +50,6 @@
           SecurityCadet: [ 2, 2 ] #intern, not counted
           Lawyer: [ 1, 1 ]
           #supply (4)
-          SalvageSpecialist: [ 2, 2 ]
           CargoTechnician: [ 2, 2 ]
           #civilian (3+)
           Passenger: [ -1, -1 ] #infinite, not counted
@@ -60,5 +57,4 @@
           Mime: [ 1, 1 ]
           Musician: [ 1, 1 ]
           #silicon (3)
-          StationAi: [ 1, 1 ]
           Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -21,7 +21,6 @@
           availableJobs: # 66 jobs total w/o latejoins & interns, 91 jobs total w/ latejoins & interns
             #command (7)
             Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]
@@ -37,7 +36,6 @@
             ServiceWorker: [ 2, 2 ]
             Reporter: [ 2, 3 ]
             #engineering (8)
-            AtmosphericTechnician: [ 4, 4 ]
             StationEngineer: [ 4, 4 ]
             TechnicalAssistant: [ 4, 4 ] #intern, not counted
             #medical (9)
@@ -56,7 +54,6 @@
             SecurityCadet: [ 4, 4 ] #intern, not counted
             Lawyer: [ 1, 2 ]
             #supply (8 - 10)
-            SalvageSpecialist: [ 4, 4 ] #the salvagers yearn for the mines
             CargoTechnician: [ 4, 6 ]
             #civilian (3 - 4+)
             Passenger: [ -1, -1 ]  #infinite, the tiders yearn for the mines
@@ -65,4 +62,3 @@
             Musician: [ 1, 1 ]
             #silicon (3 - 5)
             Borg: [ 2, 4 ]
-            StationAi: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -26,7 +26,6 @@
             Chef: [ 1, 1 ]
             Janitor: [ 1, 1 ]
             #engineering (2 - 3)
-            AtmosphericTechnician: [ 1, 1 ]
             StationEngineer: [ 1, 2 ]
             #medical (2 - 3)
             Chemist: [ 1, 1 ]
@@ -37,7 +36,6 @@
             SecurityOfficer: [ 1, 3 ]
             #supply (2)
             CargoTechnician: [ 1, 1 ]
-            SalvageSpecialist: [ 1, 1 ]
             #civilian (3+)
             Passenger: [ -1, -1 ] #infinite, not counted
             Clown: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/relic.yml
+++ b/Resources/Prototypes/Maps/relic.yml
@@ -32,7 +32,6 @@
           availableJobs:
             #command (6)
             Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
@@ -40,7 +39,6 @@
             #service (1)
             Chaplain: [ 1, 1 ]
             #engineering (4)
-            AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 2, 2 ]
             TechnicalAssistant: [ 2, 2 ] #intern, not counted
             #medical (4)

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -18,7 +18,6 @@
           availableJobs: # 45 jobs total w/o latejoins & interns, 62 jobs total w/ latejoins & interns
             #command (7)
             Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
@@ -33,7 +32,6 @@
             Librarian: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
             #engineering (6)
-            AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 4, 4 ]
             TechnicalAssistant: [ 4, 4 ] #intern, not counted
             #medical (6)
@@ -50,7 +48,6 @@
             SecurityOfficer: [ 4, 4 ]
             SecurityCadet: [ 4, 4 ] #intern, not counted
             #supply (3 - 5)
-            SalvageSpecialist: [ 1, 3 ]
             CargoTechnician: [ 2, 2 ]
             #civilian (3+)
             Passenger: [ -1, -1 ] #infinite, not counted

--- a/Resources/Prototypes/Maps/serpentcrest.yml
+++ b/Resources/Prototypes/Maps/serpentcrest.yml
@@ -17,16 +17,15 @@
         - type: StationCargoShuttle
           path: /Maps/Shuttles/cargo_syndicate.yml
         - type: StationJobs
-          availableJobs: 
+          availableJobs:
             #command (7)
             Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
             ResearchDirector: [ 1, 1 ]
             Quartermaster: [ 1, 1 ]
-            #service 
+            #service
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 2 ]
             Chef: [ 2, 2 ]
@@ -35,11 +34,10 @@
             Librarian: [ 1, 1 ]
             ServiceWorker: [ 2, 3 ]
             Reporter: [ 1, 1 ]
-            #engineering 
-            AtmosphericTechnician: [ 3, 3 ]
+            #engineering
             StationEngineer: [ 4, 5 ]
             TechnicalAssistant: [ 3, 3 ] #intern, not counted
-            #medical 
+            #medical
             Chemist: [ 3, 3 ]
             MedicalDoctor: [ 5, 5 ]
             Paramedic: [ 2, 2 ]
@@ -47,20 +45,18 @@
             #science (5)
             Scientist: [ 5, 5 ]
             ResearchAssistant: [ 4, 4 ] #intern, not counted
-            #security 
+            #security
             Warden: [ 1, 1 ]
             SecurityOfficer: [ 5, 6 ]
             Detective: [ 1, 1 ]
             SecurityCadet: [ 3, 3 ] #intern, not counted
             Lawyer: [ 2, 2 ]
-            #supply 
-            SalvageSpecialist: [ 4, 4 ]
+            #supply
             CargoTechnician: [ 4, 5 ]
-            #civilian 
+            #civilian
             Passenger: [ -1, -1 ] #infinite, not counted
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
-            #silicon 
+            #silicon
             Borg: [ 3, 3 ]
-            StationAi: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/snowball.yml
+++ b/Resources/Prototypes/Maps/snowball.yml
@@ -19,7 +19,6 @@
           availableJobs: # 49 roundstart jobs without interns,  75 total jobs including interns
             #command (7)
             Captain: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             ChiefEngineer: [ 1, 1 ]
@@ -34,7 +33,6 @@
             Librarian: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
             #engineering (5 - 7)
-            AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 3, 5 ]
             TechnicalAssistant: [ 3, 3 ] #intern, not counted
             #medical (6 - 8)
@@ -52,7 +50,6 @@
             SecurityCadet: [ 4, 4 ] #intern, not counted
             Lawyer: [ 1, 1 ]
             #supply (6-8)
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 5 ]
             #civilian (3+)
             Passenger: [ -1, -1 ] #infinite, not counted
@@ -60,5 +57,4 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             #silicon (3)
-            StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -8,7 +8,7 @@
       role: JobCargoTechnician
       time: 5h
     - !type:RoleTimeRequirement
-      role: JobSalvageSpecialist
+      role: JobBotanist #funky - replaces salvage
       time: 2.5h
     - !type:DepartmentTimeRequirement
       department: Cargo

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -9,6 +9,7 @@
   access:
   - Service
   - Maintenance
+  - Library # funky
 
 - type: startingGear
   id: LibrarianGear

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -4,12 +4,12 @@
   description: job-description-ce
   playTimeTracker: JobChiefEngineer
   requirements:
-    - !type:RoleTimeRequirement
-      role: JobAtmosphericTechnician
-      time: 2.5h
-    - !type:RoleTimeRequirement
-      role: JobStationEngineer
-      time: 5h
+#    - !type:RoleTimeRequirement
+#     role: JobAtmosphericTechnician
+#     time: 2.5h
+#   - !type:RoleTimeRequirement
+#     role: JobStationEngineer
+#     time: 5h
     - !type:DepartmentTimeRequirement
       department: Engineering
       time: 10h

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -14,7 +14,6 @@
   - Maintenance
   - Engineering
   - External
-  extendedAccess:
   - Atmospherics
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -7,7 +7,7 @@
   - Botanist # Funky - Moved from Civilian
   - CargoTechnician
   - Quartermaster
-  - SalvageSpecialist
+  # - SalvageSpecialist - funky
 
 - type: department
   id: Civilian
@@ -59,10 +59,13 @@
   - Captain
   - ChiefEngineer
   - ChiefMedicalOfficer
-  - HeadOfPersonnel
-  - HeadOfSecurity
+#  - HeadOfPersonnel - funky
+#  - HeadOfSecurity - funky
   - ResearchDirector
   - Quartermaster
+  - HospitalityDirector # funky
+  - CorporateLiaison # funky
+  - ExecutiveOfficer # funky
   - CentralCommandOfficial
   - CBURN
   - ERTLeader
@@ -81,7 +84,7 @@
   description: department-Engineering-description
   color: "#EFB341"
   roles:
-  - AtmosphericTechnician
+  #- AtmosphericTechnician - funky
   - ChiefEngineer
   - StationEngineer
   - TechnicalAssistant
@@ -129,7 +132,7 @@
   color: "#D381C9"
   roles:
   - Borg
-  - StationAi
+  #- StationAi - funky
 
 - type: department
   id: Specific

--- a/Resources/Prototypes/_Funkystation/Access/command.yml
+++ b/Resources/Prototypes/_Funkystation/Access/command.yml
@@ -1,0 +1,3 @@
+- type: accessLevel
+  id: Corporate
+  name: id-card-access-level-cl

--- a/Resources/Prototypes/_Funkystation/Access/internalaffairs.yml
+++ b/Resources/Prototypes/_Funkystation/Access/internalaffairs.yml
@@ -1,0 +1,11 @@
+- type: accessLevel
+  id: InternalAffairs
+  name: id-card-access-level-ia
+
+- type: accessLevel
+  id: Magistrate
+  name: id-card-access-level-magistrate
+
+- type: accessLevel
+  id: ExecutiveOfficer
+  name: id-card-access-level-xo

--- a/Resources/Prototypes/_Funkystation/Access/service.yml
+++ b/Resources/Prototypes/_Funkystation/Access/service.yml
@@ -1,0 +1,7 @@
+- type: accessLevel
+  id: Library
+  name: id-card-access-level-library
+
+- type: accessLevel
+  id: HospitalityDirector
+  name: id-card-access-level-hd

--- a/Resources/Prototypes/_Funkystation/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Clothing/Ears/headsets.yml
@@ -1,0 +1,48 @@
+- type: entity
+  parent: ClothingHeadset
+  id: ClothingHeadsetInternalAffairs
+  name: internal affairs headset
+  components:
+  - type: Sprite
+    sprite: Clothing/Ears/Headsets/mining.rsi
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyIA
+      - EncryptionKeyCommon
+
+- type: entity
+  parent: ClothingHeadsetInternalAffairs
+  id: ClothingHeadsetMagistrate
+  name: magistrate's headset
+  components:
+  - type: Sprite
+    sprite: Clothing/Ears/Headsets/mining.rsi
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyIA
+      - EncryptionKeyCommon
+      - EncryptionKeySecurity
+
+- type: entity
+  parent: ClothingHeadsetService
+  id: ClothingHeadsetHD
+  name: hospitality director's headset
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCommand
+      - EncryptionKeyService
+
+- type: entity
+  parent: ClothingHeadsetCentCom
+  id: ClothingHeadsetCL
+  name: corporate liaison's headset
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCommand
+      - EncryptionKeyCentCom

--- a/Resources/Prototypes/_Funkystation/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Markers/Spawners/jobs.yml
@@ -1,0 +1,59 @@
+- type: entity
+  id: SpawnPointInternalAffairsAgent
+  parent: SpawnPointJobBase
+  name: internalaffairs
+  components:
+  - type: SpawnPoint
+    job_id: InternalAffairsAgent
+  - type: Sprite
+    layers:
+    - state: green
+    - state: lawyer
+
+- type: entity
+  id: SpawnPointMagistrate
+  parent: SpawnPointJobBase
+  name: magistrate
+  components:
+  - type: SpawnPoint
+    job_id: Magistrate
+  - type: Sprite
+    layers:
+    - state: green
+    - state: lawyer
+
+- type: entity
+  id: SpawnPointCorporateLiaison
+  parent: SpawnPointJobBase
+  name: corporateliaison
+  components:
+  - type: SpawnPoint
+    job_id: CorporateLiaison
+  - type: Sprite
+    layers:
+    - state: green
+    - state: lawyer
+
+- type: entity
+  id: SpawnPointHospitalityDirector
+  parent: SpawnPointJobBase
+  name: hospitalitydirector
+  components:
+  - type: SpawnPoint
+    job_id: HospitalityDirector
+  - type: Sprite
+    layers:
+    - state: green
+    - state: hop
+
+- type: entity
+  id: SpawnPointExecutiveOfficer
+  parent: SpawnPointJobBase
+  name: executiveofficer
+  components:
+  - type: SpawnPoint
+    job_id: ExecutiveOfficer
+  - type: Sprite
+    layers:
+    - state: green
+    - state: hop

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/Electronics/door_access.yml
@@ -5,3 +5,52 @@
   components:
   - type: AccessReader
     access: [["Newsroom"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsLibrary
+  suffix: Library, Locked
+  components:
+  - type: AccessReader
+    access: [["Library"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsHospitalityDirector
+  suffix: HospitalityDirector, Locked
+  components:
+  - type: AccessReader
+    access: [["HospitalityDirector"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsInternalAffairs
+  suffix: InternalAffairs, Locked
+  components:
+  - type: AccessReader
+    access: [["InternalAffairs"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsMagistrate
+  suffix: Magistrate, Locked
+  components:
+  - type: AccessReader
+    access: [["Magistrate"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsExecutiveOfficer
+  suffix: ExecutiveOfficer, Locked
+  components:
+  - type: AccessReader
+    access: [["ExecutiveOfficer"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsCorporate
+  suffix: Corporate, Locked
+  components:
+  - type: AccessReader
+    access: [["Corporate"]]
+

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/encryption_keys.yml
@@ -1,0 +1,15 @@
+- type: entity
+  parent: EncryptionKeyCommon
+  id: EncryptionKeyIA
+  name: IA encryption key
+  description: An encryption key used by internal affairs employees.
+  components:
+  - type: EncryptionKey
+    channels:
+    - InternalAffairs
+    defaultChannel: InternalAffairs
+  - type: Sprite
+    layers:
+    - state: crypt_gray
+    - state: common_label
+

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/identification_card.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/identification_card.yml
@@ -1,0 +1,39 @@
+- type: entity
+  parent: LawyerIDCard
+  id: IAAIDCard
+  name: internal affairs ID card
+  components:
+  - type: PresetIdCard
+    job: InternalAffairsAgent
+
+- type: entity
+  parent: LawyerIDCard
+  id: MagistrateIDCard
+  name: magistrate ID card
+  components:
+  - type: PresetIdCard
+    job: Magistrate
+
+- type: entity
+  parent: HoPIDCard
+  id: XOIDCard
+  name: executive officer ID card
+  components:
+  - type: PresetIdCard
+    job: ExecutiveOfficer
+
+- type: entity
+  parent: HoPIDCard
+  id: HDIDCard
+  name: hospitality director ID card
+  components:
+  - type: PresetIdCard
+    job: HospitalityDirector
+
+- type: entity
+  parent: LawyerIDCard
+  id: CLIDCard
+  name: corporate liaison ID card
+  components:
+  - type: PresetIdCard
+    job: CorporateLiaison

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/pda.yml
@@ -1,0 +1,72 @@
+- type: entity
+  parent: LawyerPDA
+  id: IAAPDA
+  name: internal affairs PDA
+  description: A boring PDA for a boring paper-pusher.
+  components:
+  - type: Pda
+    id: IAAIDCard
+    penSlot:
+      startingItem: LuxuryPen
+      priority: -1
+      whitelist:
+        tags:
+        - Write
+
+- type: entity
+  parent: IAAPDA
+  id: MagistratePDA
+  name: magistrate PDA
+  components:
+  - type: Pda
+    id: MagistrateIDCard
+    penSlot:
+      startingItem: LuxuryPen
+      priority: -1
+      whitelist:
+        tags:
+        - Write
+
+- type: entity
+  parent: HoPPDA
+  id: XOPDA
+  name: executive officer PDA
+  components:
+  - type: Pda
+    id: XOIDCard
+    penSlot:
+      startingItem: PenHop
+      priority: -1
+      whitelist:
+        tags:
+        - Write
+
+- type: entity
+  parent: ServiceWorkerPDA
+  id: HDPDA
+  name: hospitality director PDA
+  description: It seems stained with coffee.
+  components:
+  - type: Pda
+    id: HDIDCard
+    penSlot:
+      startingItem: Pen
+      priority: -1
+      whitelist:
+        tags:
+        - Write
+
+- type: entity
+  parent: ClearPDA
+  id: CLPDA
+  name: corporate liaison PDA
+  description: A boring PDA for a boring paper-pusher.
+  components:
+  - type: Pda
+    id: CLIDCard
+    penSlot:
+      startingItem: LuxuryPen
+      priority: -1
+      whitelist:
+        tags:
+        - Write

--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Doors/Airlocks/access.yml
@@ -9,6 +9,72 @@
   - type: Wires
     layoutId: AirlockService # Civilian jobs use the same wire layout as Service because NT is cheap like that
 
+- type: entity
+  parent: Airlock
+  id: AirlockLibraryLocked
+  suffix: Library, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsLibrary ]
+  - type: Wires
+    layoutId: AirlockService
+
+- type: entity
+  parent: AirlockSecurity
+  id: AirlockInternalAffairsLocked
+  suffix: InternalAffairs, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsInternalAffairs ]
+  - type: Wires
+    layoutId: AirlockSecurity
+
+- type: entity
+  parent: AirlockSecurity
+  id: AirlockMagistrateLocked
+  suffix: Magistrate, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMagistrate ]
+  - type: Wires
+    layoutId: AirlockSecurity
+
+- type: entity
+  parent: AirlockCommand
+  id: AirlockExecutiveOfficerLocked
+  suffix: ExecutiveOfficer, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsExecutiveOfficer ]
+  - type: Wires
+    layoutId: AirlockCommand
+
+- type: entity
+  parent: AirlockCommand
+  id: AirlockHospitalityDirectorLocked
+  suffix: HospitalityDirector, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsHospitalityDirector ]
+  - type: Wires
+    layoutId: AirlockCommand
+
+- type: entity
+  parent: AirlockCommand
+  id: AirlockCorporateLocked
+  suffix: Corporate, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCorporate ]
+  - type: Wires
+    layoutId: AirlockCommand
+
 # Glass Airlocks
 
 - type: entity
@@ -21,3 +87,69 @@
       board: [ DoorElectronicsNewsroom ]
   - type: Wires
     layoutId: AirlockService
+
+- type: entity
+  parent: AirlockGlass
+  id: AirlockLibraryGlassLocked
+  suffix: Library, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsLibrary ]
+  - type: Wires
+    layoutId: AirlockService
+
+- type: entity
+  parent: AirlockSecurityGlass
+  id: AirlockInternalAffairsGlassLocked
+  suffix: InternalAffairs, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsInternalAffairs ]
+  - type: Wires
+    layoutId: AirlockSecurity
+
+- type: entity
+  parent: AirlockSecurityGlass
+  id: AirlockMagistrateGlassLocked
+  suffix: Magistrate, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMagistrate ]
+  - type: Wires
+    layoutId: AirlockSecurity
+
+- type: entity
+  parent: AirlockCommandGlass
+  id: AirlockExecutiveOfficerGlassLocked
+  suffix: ExecutiveOfficer, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsExecutiveOfficer ]
+  - type: Wires
+    layoutId: AirlockCommand
+
+- type: entity
+  parent: AirlockCommandGlass
+  id: AirlockHospitalityDirectorGlassLocked
+  suffix: HospitalityDirector, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsHospitalityDirector ]
+  - type: Wires
+    layoutId: AirlockCommand
+
+- type: entity
+  parent: AirlockCommandGlass
+  id: AirlockCorporateGlassLocked
+  suffix: Corporate, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCorporate ]
+  - type: Wires
+    layoutId: AirlockCommand

--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/telecomms.yml
@@ -1,0 +1,9 @@
+- type: entity
+  parent: TelecomServer
+  id: TelecomServerFilledIA
+  suffix: Internal Affairs
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyIA

--- a/Resources/Prototypes/_Funkystation/Loadouts/RoleLoadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Funkystation/Loadouts/RoleLoadouts/role_loadouts.yml
@@ -1,0 +1,71 @@
+- type: roleLoadout
+  id: JobHospitalityDirector
+  groups:
+  - GroupTankHarness
+  - GroupTankHarness
+  - BartenderJumpsuit
+  - CommonBackpack
+  - Glasses
+  - Survival
+  - Trinkets
+  #- ServiceWorkerJobTrinkets
+  - GroupSpeciesBreathTool
+  - GroupBreathToolDecapoid # MACRO: Decapoid
+
+- type: roleLoadout
+  id: JobMagistrate
+  groups:
+  - GroupTankHarness
+  - LawyerNeck
+  - LawyerJumpsuit
+  - CommonBackpack
+  - Glasses
+  - Survival
+  - Trinkets
+  #- LawyerJobTrinkets
+  - GroupSpeciesBreathTool
+  - GroupBreathToolDecapoid # MACRO: Decapoid
+
+- type: roleLoadout
+  id: JobInternalAffairsAgent
+  groups:
+  - GroupTankHarness
+  - LawyerNeck
+  - LawyerJumpsuit
+  - CommonBackpack
+  - Glasses
+  - Survival
+  - Trinkets
+  #- LawyerJobTrinkets
+  - GroupSpeciesBreathTool
+  - GroupBreathToolDecapoid # MACRO: Decapoid
+
+- type: roleLoadout
+  id: JobCorporateLiaison
+  groups:
+  - GroupTankHarness
+  - LawyerNeck
+  - LawyerJumpsuit
+  - CommonBackpack
+  - Glasses
+  - Survival
+  - Trinkets
+  #- LawyerJobTrinkets
+  - GroupSpeciesBreathTool
+  - GroupBreathToolDecapoid # MACRO: Decapoid
+
+- type: roleLoadout
+  id: JobExecutiveOfficer
+  groups:
+  - GroupTankHarness
+  - HoPHead
+  - HoPNeck
+  - HoPJumpsuit
+  - HoPBackpack
+  - HoPOuterClothing
+  - Glasses
+  - Survival
+  - Trinkets
+  #- HoPJobTrinkets
+  - GroupSpeciesBreathTool
+  - GroupBreathToolDecapoid # MACRO: Decapoid

--- a/Resources/Prototypes/_Funkystation/Loadouts/RoleLoadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Funkystation/Loadouts/RoleLoadouts/role_loadouts.yml
@@ -16,7 +16,6 @@
   id: JobMagistrate
   groups:
   - GroupTankHarness
-  - LawyerNeck
   - LawyerJumpsuit
   - CommonBackpack
   - Glasses
@@ -44,7 +43,6 @@
   id: JobCorporateLiaison
   groups:
   - GroupTankHarness
-  - LawyerNeck
   - LawyerJumpsuit
   - CommonBackpack
   - Glasses

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/Command/corporateliaison.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/Command/corporateliaison.yml
@@ -21,6 +21,17 @@
 - type: startingGear
   id: CLGear
   equipment:
+    head: ClothingHeadHatBeretCommand
+    eyes: ClothingEyesGlassesSunglasses
     shoes: ClothingShoesBootsLaceup
     id: CLPDA
     ears: ClothingHeadsetCL
+
+- type: chameleonOutfit
+  id: CLChameleonOutfit
+  job: CorporateLiaison
+  hasMindShield: true
+  equipment:
+    mask: ClothingMaskNeckGaiter
+    neck: ClothingNeckScarfStripedBlue
+    outerClothing: ClothingOuterWinterColorBlue

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/Command/corporateliaison.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/Command/corporateliaison.yml
@@ -1,0 +1,26 @@
+- type: job
+  id: CorporateLiaison
+  name: job-name-cl
+  description: job-description-cl
+  playTimeTracker: JobCorporateLiaison
+  requirements:
+  - !type:DepartmentTimeRequirement
+    department: Command
+    time: 10h
+  - !type:DepartmentTimeRequirement
+    department: InternalAffairs
+    time: 10h
+  startingGear: CLGear
+  icon: "JobIconCorporateLiaison"
+  supervisors: job-supervisors-cl
+  access:
+  - Corporate
+  - Command
+  - Maintenance
+
+- type: startingGear
+  id: CLGear
+  equipment:
+    shoes: ClothingShoesBootsLaceup
+    id: CLPDA
+    ears: ClothingHeadsetCL

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/executiveofficer.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/executiveofficer.yml
@@ -79,3 +79,14 @@
   storage:
     back:
     - Flash
+
+- type: chameleonOutfit
+  id: XOChameleonOutfit
+  job: ExecutiveOfficer
+  hasMindShield: true
+  equipment:
+    head: ClothingHeadHatHopcap
+    eyes: ClothingEyesHudCommand
+    mask: ClothingMaskNeckGaiterRed
+    neck: ClothingNeckCloakHop
+    outerClothing: ClothingOuterWinterHoP

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/executiveofficer.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/executiveofficer.yml
@@ -1,0 +1,81 @@
+- type: job
+  id: ExecutiveOfficer
+  name: job-name-xo # funkystation
+  description: job-description-xo # funkystation
+  playTimeTracker: JobExecutiveOfficer
+  requirements:
+  - !type:DepartmentTimeRequirement
+    department: Engineering
+    time: 2.5h
+  - !type:DepartmentTimeRequirement
+    department: Medical
+    time: 2.5h
+  - !type:DepartmentTimeRequirement
+    department: Science
+    time: 2.5h
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 2.5h
+  - !type:DepartmentTimeRequirement
+    department: Command
+    time: 2.5h
+  - !type:DepartmentTimeRequirement
+    department: InternalAffairs
+    time: 10h
+  - !type:RoleTimeRequirement
+    role: JobMagistrate
+    time: 2.5h
+  weight: 20
+  startingGear: XOGear
+  icon: "JobIconHeadOfPersonnel"
+  joinNotifyCrew: true
+  supervisors: job-supervisors-captain
+  access:
+  - Command
+  - ExecutiveOfficer
+  - Bar
+  - Service
+  - Maintenance
+  - Janitor
+  - Theatre
+  - Kitchen
+  - Chapel
+  - Hydroponics
+  - External
+  - Cryogenics
+  - Chemistry
+  - Engineering
+  - Research
+  - Detective
+  - Salvage
+  - Security
+  - Brig
+  - Lawyer
+  - Cargo
+  - Atmospherics
+  - Medical
+  - GenpopEnter
+  - GenpopLeave
+  - InternalAffairs
+  - Magistrate
+  - Newsroom
+  - Library
+  special:
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant ]
+  - !type:AddComponentSpecial
+    components:
+    - type: CommandStaff
+
+- type: startingGear
+  id: XOGear
+  equipment:
+    shoes: ClothingShoesColorBrown
+    id: XOPDA
+    gloves: ClothingHandsGlovesHop
+    ears: ClothingHeadsetAltCommand
+    belt: BoxFolderClipboardThreePapers
+    eyes: ClothingEyesHudCommand
+  storage:
+    back:
+    - Flash

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/internalaffairs.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/internalaffairs.yml
@@ -2,7 +2,7 @@
   id: InternalAffairsAgent
   name: job-name-iaa
   description: job-description-iaa
-  playTimeTracker: JobInternalAffairs
+  playTimeTracker: JobIAA
   requirements:
    - !type:RoleTimeRequirement
      role: JobLawyer
@@ -14,7 +14,7 @@
   - InternalAffairs
   - Brig
   - Medical
-  - Science
+  - Research
   - Engineering
   - Cargo
   - Bar

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/internalaffairs.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/internalaffairs.yml
@@ -1,0 +1,30 @@
+- type: job
+  id: InternalAffairsAgent
+  name: job-name-iaa
+  description: job-description-iaa
+  playTimeTracker: JobInternalAffairs
+  requirements:
+   - !type:RoleTimeRequirement
+     role: JobLawyer
+     time: 5h
+  startingGear: IAAGear
+  icon: "JobIconInternalAffairsAgent"
+  supervisors: job-supervisors-ia
+  access:
+  - InternalAffairs
+  - Brig
+  - Medical
+  - Science
+  - Engineering
+  - Cargo
+  - Bar
+  - Kitchen
+  - Service
+  - Maintenance
+
+- type: startingGear
+  id: IAAGear
+  equipment:
+    shoes: ClothingShoesBootsLaceup
+    id: IAAPDA
+    ears: ClothingHeadsetInternalAffairs

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/internalaffairs.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/internalaffairs.yml
@@ -25,6 +25,18 @@
 - type: startingGear
   id: IAAGear
   equipment:
+    head: ClothingHeadHatFedoraBrown
     shoes: ClothingShoesBootsLaceup
     id: IAAPDA
+    eyes: ClothingEyesGlassesSunglasses
     ears: ClothingHeadsetInternalAffairs
+    outerClothing: ClothingOuterCoatTrench
+
+- type: chameleonOutfit
+  id: IAAChameleonOutfit
+  job: InternalAffairsAgent
+  hasMindShield: true
+  equipment:
+    mask: ClothingMaskNeckGaiterRed
+    neck: ClothingNeckLawyerbadge
+

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/magistrate.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/magistrate.yml
@@ -1,0 +1,24 @@
+- type: job
+  id: Magistrate
+  name: job-name-magistrate
+  description: job-description-magistrate
+  playTimeTracker: JobMagistrate
+  requirements:
+  - !type:RoleTimeRequirement
+    role: JobInternalAffairs
+    time: 5h
+  startingGear: MagistrateGear
+  icon: "JobIconMagistrate"
+  supervisors: job-supervisors-ia
+  access:
+  - Magistrate
+  - Brig
+  - InternalAffairs
+  - Maintenance
+
+- type: startingGear
+  id: MagistrateGear
+  equipment:
+    shoes: ClothingShoesBootsLaceup
+    id: MagistratePDA
+    ears: ClothingHeadsetMagistrate

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/magistrate.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/magistrate.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobMagistrate
   requirements:
   - !type:RoleTimeRequirement
-    role: JobInternalAffairs
+    role: JobIAA
     time: 5h
   startingGear: MagistrateGear
   icon: "JobIconMagistrate"

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/magistrate.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/magistrate.yml
@@ -19,6 +19,15 @@
 - type: startingGear
   id: MagistrateGear
   equipment:
+    head: ClothingHeadHatPwig
     shoes: ClothingShoesBootsLaceup
     id: MagistratePDA
     ears: ClothingHeadsetMagistrate
+    outerClothing: ClothingOuterRobesJudge
+
+- type: chameleonOutfit
+  id: MagistrateChameleonOutfit
+  job: Magistrate
+  equipment:
+    mask: ClothingMaskNeckGaiter
+    neck: ClothingNeckScarfStripedPurple

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/Service/hospitalitydirector.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/Service/hospitalitydirector.yml
@@ -1,0 +1,38 @@
+- type: job
+  id: HospitalityDirector
+  name: job-name-hd
+  description: job-description-hd
+  playTimeTracker: JobHospitalityDirector
+  requirements:
+  - !type:DepartmentTimeRequirement
+    department: Service
+    time: 10h
+  weight: 20
+  startingGear: HDGear
+  icon: "JobIconHospitalityDirector"
+  joinNotifyCrew: true
+  supervisors: job-supervisors-captain
+  access:
+  - Command
+  - HospitalityDirector
+  - Bar
+  - Service
+  - Maintenance
+  - Janitor
+  - Theatre
+  - Kitchen
+  - Chapel
+  - Library
+  special:
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant ]
+  - !type:AddComponentSpecial
+    components:
+    - type: CommandStaff
+
+- type: startingGear
+  id: HDGear
+  equipment:
+    shoes: ClothingShoesColorBlack
+    id: HDPDA
+    ears: ClothingHeadsetHD

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/Service/hospitalitydirector.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/Service/hospitalitydirector.yml
@@ -33,6 +33,17 @@
 - type: startingGear
   id: HDGear
   equipment:
+    head: ClothingHeadHatTophat
     shoes: ClothingShoesColorBlack
     id: HDPDA
     ears: ClothingHeadsetHD
+
+- type: chameleonOutfit
+  id: HDChameleonOutfit
+  job: HospitalityDirector
+  hasMindShield: true
+  equipment:
+    eyes: ClothingEyesHudBeer
+    mask: ClothingMaskNeckGaiter
+    neck: ClothingNeckScarfStripedGreen
+    outerClothing: ClothingOuterWinterColorGreen

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/departments.yml
@@ -10,8 +10,19 @@
   - Chef
   - Clown
   - Janitor
-  - HeadOfPersonnel
+  - HospitalityDirector
   - Librarian
   - Mime
   - Musician
   - ServiceWorker
+
+- type: department
+  id: InternalAffairs
+  name: department-InternalAffairs
+  description: department-InternalAffairs-description
+  color: "#BDA499"
+  weight: 10 # important, but not as much as security
+  roles:
+  - ExecutiveOfficer
+  - Magistrate
+  - InternalAffairsAgent

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/play_time_trackers.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/play_time_trackers.yml
@@ -1,0 +1,14 @@
+- type: playTimeTracker
+  id: JobMagistrate
+
+- type: playTimeTracker
+  id: JobIAA
+
+- type: playTimeTracker
+  id: JobHospitalityDirector
+
+- type: playTimeTracker
+  id: JobCorporateLiaison
+
+- type: playTimeTracker
+  id: JobExecutiveOfficer

--- a/Resources/Prototypes/_Funkystation/radio_channels.yml
+++ b/Resources/Prototypes/_Funkystation/radio_channels.yml
@@ -1,0 +1,6 @@
+- type: radioChannel
+  id: InternalAffairs
+  name: chat-radio-ia
+  keycode: "i"
+  frequency: 1375
+  color: "#bda499"


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
Partially restructured the job heirarchy as outlined by the SOP workgroup. Does **NOT** add any new sprites, everything used is intended as a placeholder.

Most of the planned Security changes are not finalized, so they will be added in a later PR.

This PR adds five new jobs: 

- Executive Officer (supplants HoP as right-hand to the Captain)
- Magistrate (parity with live codebase)
- Internal Affairs Agent (parity with live codebase)
- Hospitality Director (supplants HoP as head of the Service department)
- Corporate Liaison (replaces Nanotrasen Representative from the live codebase)

The former three roles comprise the new Internal Affairs department. This PR also included a comms channel and telecomms server for the department. The latter two also have their own headsets incorporating existing channels.

IAA and Magistrate are no longer part of the Command hierarchy, and as such no longer have knowledge of the CTM or Command comms.

The loadouts are all placeholders, to be fleshed out by ports and sprite PRs.

Head of Personnel, Salvage Specialist, Atmospheric Technician, and Station AI are all being deprecated. Chief Engineer and Quartermaster have had time requirements adjusted to accomodate. Engineers also have Atmospherics access, matching the live codebase.

The Library has its own unique access now. This is for live codebase parity.

Head of Security is removed from Command. Currently, this only matters for playtime tracking and role organization, and will be elaborated upon once further Security changes are finalized. 

## Technical details
Mostly YAML, but the ID card computer component has been modified for the new accesses.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
You can test accesses by walking into doors with the matching ID on. If you want to test round start spawning, you'll have to modify a map's prototype, so if you don't want to do that you'll just have to take my word for it that it works.


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
<img width="684" height="563" alt="Screenshot from 2026-08-05 22-15-35" src="https://github.com/user-attachments/assets/36ca4d01-7ec0-4df0-8a60-27307145ab04" />
<img width="766" height="675" alt="Screenshot from 2026-08-05 19-17-15" src="https://github.com/user-attachments/assets/c94449ae-7e81-4c2b-a1d1-f650b85ea9cc" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->
This fundamentally changes the job structure. If downstreams want to re-enable the disabled jobs, they may simply uncomment the relevant lines in departments.yml and add the job slot back to the map prototypes.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
:cl:
- add: Added new department: Internal Affairs. Comes with a radio channel and telecomms server.
- add: Added Executive Officer, Magistrate, Internal Affairs Agent, Hospitality Director, and Corporate Liaison as round-start roles.
- add: Added ID cards, PDAs, and headsets for the new roles where necessary.
- add: Station Engineers now have Atmospherics access.
- add: The Library has been given its own unique access.
- remove: Disabled Head of Personnel, Salvage Specialist, Atmostheric Technician, and Station AI as round-start roles.
- tweak: Chief Engineer and Quartermaster time requirements adjusted to accomodate for disabled roles.
- tweak: The Head of Security is no longer included in the Command category.
