### PR TITLE
Removing mindshields

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -108,15 +108,15 @@
   category: cargoproduct-category-name-medical
   group: market
 
-- type: cargoProduct
-  id: MedicalMindShieldImplants
-  icon:
-    sprite: Objects/Specific/Medical/implanter.rsi
-    state: implanter0
-  product: CrateMindShieldImplants
-  cost: 3000
-  category: cargoproduct-category-name-medical
-  group: market
+#- type: cargoProduct # Funky - Removing mindshields
+#  id: MedicalMindShieldImplants
+#  icon:
+#    sprite: Objects/Specific/Medical/implanter.rsi
+#    state: implanter0
+#  product: CrateMindShieldImplants
+#  cost: 3000
+#  category: cargoproduct-category-name-medical
+#  group: market
 
 - type: cargoProduct
   id: ChemistryP

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -52,6 +52,8 @@
   id: CrateMindShieldImplants
   name: MindShield implant crate
   description: Crate filled with 3 MindShield implants.
+  suffix: DO NOT MAP # Funky - Removing mindshields
+  categories: [ DoNotMap ] # Funky
   components:
   - type: EntityTableContainerFill
     containers:

--- a/Resources/Prototypes/Catalog/Fills/Crates/permaescape.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/permaescape.yml
@@ -221,8 +221,8 @@
             weight: 0.20
           - id: SyndicateSponge
             weight: 0.20
-        - id: MindShieldImplanter
-          prob: 0.20
+        #- id: MindShieldImplanter # Funky - Removing mindshields
+        #  prob: 0.20
         - id: ClothingHandsGlovesConducting # funny
           prob: 0.30
         - id: CigPackSyndicate

--- a/Resources/Prototypes/Catalog/Fills/Crates/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/security.yml
@@ -95,6 +95,8 @@
   id: CrateSecurityTrackingMindshieldImplants
   name: implanter crate
   description: Contains 4 MindShield implants and 4 tracking implant. Requires Security access to open.
+  suffix: DO NOT MAP # Funky - Removing mindshields
+  categories: [ DoNotMap ] # Funky
   components:
   - type: EntityTableContainerFill
     containers:

--- a/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
+++ b/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
@@ -8,7 +8,7 @@
   content:
   - ClothingBackpackChameleonFillAgent
   - ChameleonProjector
-  - FakeMindShieldImplanter
+  #- FakeMindShieldImplanter # Funky - Removing mindshields
 
 - type: thiefBackpackSet
   id: ToolsSet

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1715,18 +1715,18 @@
         components:
           - SurplusBundle
 
-- type: listing
-  id: UplinkFakeMindshield
-  name: uplink-fake-mindshield-name
-  description: uplink-fake-mindshield-desc
-  icon: { sprite: Interface/Actions/actions_fakemindshield.rsi, state: icon-on }
-  productEntity: FakeMindShieldImplanter
-  discountDownTo:
-    Telecrystal: 10
-  cost:
-    Telecrystal: 15
-  categories:
-  - UplinkImplants
+#- type: listing # Funky - Removing mindshields
+#  id: UplinkFakeMindshield
+#  name: uplink-fake-mindshield-name
+#  description: uplink-fake-mindshield-desc
+#  icon: { sprite: Interface/Actions/actions_fakemindshield.rsi, state: icon-on }
+#  productEntity: FakeMindShieldImplanter
+#  discountDownTo:
+#    Telecrystal: 10
+#  cost:
+#    Telecrystal: 15
+#  categories:
+#  - UplinkImplants
 
 - type: listing
   id: UplinkVoiceMaskImplant

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/crates.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/crates.yml
@@ -244,7 +244,7 @@
         - id: CrateArmoryPistols
         - id: CrateTrainingBombs
         - id: CrateTrackingImplants
-        - id: CrateSecurityTrackingMindshieldImplants
+        #- id: CrateSecurityTrackingMindshieldImplants # Funky - Removing mindshieldsResources/Prototypes/_Funkystation/Catalog/Fills/Crates/security.yml
         - id: CrateSecurityHelmet
         - id: CrateSecurityArmor
         - id: CrateRestraints

--- a/Resources/Prototypes/Entities/Markers/Spawners/nuke_ops_spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/nuke_ops_spawners.yml
@@ -39,9 +39,9 @@
     - id: RadioJammer
     - id: BorgModuleMartyr
     - id: ScramImplant
-    - id: FakeMindShieldImplanter
-      amount: !type:RangeNumberSelector
-        range: 1, 3
+    #- id: FakeMindShieldImplanter # Funky - Removing mindshields
+    #  amount: !type:RangeNumberSelector
+    #    range: 1, 3
     - id: EmpImplanter
     - id: MicroBombImplanter
     - id: SlipocalypseClusterSoap

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -6,13 +6,16 @@
     - type: GhostTakeoverAvailable
     - type: IdBind
 
+# Funky - Ideally this should be called something like EventHumanoidAntagImmune or something now
+# However that would mean changing every single thing that uses this and that is not really ideal
+# Plus to my knowledge this is just used for admemes given that visitor shuttles have been removed
 - type: randomHumanoidSettings
   id: EventHumanoidMindShielded
   parent: EventHumanoid
   components:
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
+    #- type: AutoImplant # Funky - Removing mindshields
+    #  implants:
+    #  - MindShieldImplant
     - type: AntagImmune
 
 - type: randomHumanoidSettings
@@ -22,7 +25,7 @@
   components:
   - type: AutoImplant
     implants:
-    - MindShieldImplant
+    #- MindShieldImplant # Funky - Removing mindshields
     - DeathRattleImplantCentcomm
 
 ## Death Squad

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -41,8 +41,8 @@
     - MacroBombImplant
     - DeathAcidifierImplant
     - DeathRattleImplant
-    - MindShieldImplant
-    - FakeMindShieldImplant
+    #- MindShieldImplant # Funky - Removing mindshields
+    #- FakeMindShieldImplant # Funky
     - RadioImplant
     - ChameleonControllerImplant
     - VoiceMaskImplant
@@ -311,6 +311,8 @@
   id: MindShieldImplanter
   name: mindshield implanter
   parent: BaseImplantOnlyImplanter
+  suffix: DO NOT MAP # Funky - Removing mindshields
+  categories: [ DoNotMap ] # Funky
   components:
   - type: Implanter
     implant: MindShieldImplant

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -29,8 +29,8 @@
   - Brig
   - Cryogenics
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant ] # Funky - Removed mindshields
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
@@ -13,7 +13,8 @@
   - CentralCommand
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    #implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    implants: [ DeathRattleImplantCentcomm ] # Funky - Removed mindshields
 
 - type: startingGear
   id: CBURNGear

--- a/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
@@ -11,9 +11,12 @@
   - AllAccess
   access:
   - CentralCommand
+  #special:
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    implants: [ DeathRattleImplantCentcomm ] # Funky - Removed mindshields
 
 - type: startingGear
   id: DeathSquadGear

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -13,7 +13,8 @@
   - CentralCommand
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    #implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    implants: [ DeathRattleImplantCentcomm ] # Funky - Removed mindshields
 
 - type: startingGear
   parent: ERTLeaderGearEVA
@@ -112,7 +113,8 @@
     components:
     - type: BibleUser #Lets them heal with bibles
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    #implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    implants: [ DeathRattleImplantCentcomm ] # Funky - Removed mindshields
 
 - type: startingGear
   parent: ERTChaplainGearEVA
@@ -185,7 +187,8 @@
   - CentralCommand
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    #implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    implants: [ DeathRattleImplantCentcomm ] # Funky - Removed mindshields
 
 - type: startingGear
   parent: ERTEngineerGearEVA
@@ -278,7 +281,8 @@
   - CentralCommand
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    #implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    implants: [ DeathRattleImplantCentcomm ] # Funky - Removed mindshields
 
 - type: startingGear
   parent: ERTSecurityGearEVA
@@ -460,7 +464,8 @@
   - CentralCommand
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    #implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    implants: [ DeathRattleImplantCentcomm ] # Funky - Removed mindshields
 
 - type: startingGear
   parent: ERTMedicalGearEVA
@@ -556,9 +561,12 @@
   - AllAccess
   access:
   - CentralCommand
+  #special:
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    implants: [ DeathRattleImplantCentcomm ] # Funky - Removed mindshields
 
 - type: startingGear
   parent: ERTJanitorGearEVA

--- a/Resources/Prototypes/Roles/Jobs/CentComm/official.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/official.yml
@@ -13,7 +13,8 @@
   - CentralCommand
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    #implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
+    implants: [ DeathRattleImplantCentcomm ] # Funky - Removed mindshields
 
 - type: startingGear
   id: CentcommGear

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -36,8 +36,8 @@
   accessGroups:
   - AllAccess
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant ] # Funky - Removed mindshields
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -28,8 +28,8 @@
   - Brig
   - Cryogenics
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant ] # Funky - Removed mindshields
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -27,8 +27,8 @@
   - Brig
   - Cryogenics
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant ] # Funky - Removed mindshields
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -23,8 +23,8 @@
   - Brig
   - Cryogenics
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant ] # Funky - Removed mindshields
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -17,9 +17,9 @@
   - Detective
   - Cryogenics
   - External
-  special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+  #special:
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant ] # Funky - Removed mindshields
 
 - type: startingGear
   id: DetectiveGear

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -19,9 +19,9 @@
   - Maintenance
   - External
   - Cryogenics
-  special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+  #special:
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant ] # Funky - Removed mindshields
 
 - type: startingGear
   id: SecurityCadetGear

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -16,9 +16,9 @@
   - Maintenance
   - External
   - Cryogenics
-  special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+  #special:
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant ] # Funky - Removed mindshields
 
 - type: startingGear
   id: SecurityOfficerGear

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -24,9 +24,9 @@
   - Cryogenics
   - GenpopEnter
   - GenpopLeave
-  special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+  #special:
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant ] # Funky - Removed mindshields
 
 - type: startingGear
   id: WardenGear

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/executiveofficer.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/InternalAffairs/executiveofficer.yml
@@ -61,8 +61,8 @@
   - Newsroom
   - Library
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant ] # Removed mindshields
   - !type:AddComponentSpecial
     components:
     - type: CommandStaff

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/Security/commandant.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/Security/commandant.yml
@@ -33,8 +33,8 @@
   - GenpopEnter
   - GenpopLeave
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant ] # Funky - Removed mindshields
   - !type:AddComponentSpecial
     components:
     - type: CommandStaff

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/Security/dispatcher.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/Security/dispatcher.yml
@@ -15,9 +15,9 @@
   - Brig
   - Maintenance
   - External
-  special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+  #special:
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant ] # Removed mindshields
 
 - type: startingGear
   id: DispatcherGear

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/Security/lieutenant.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/Security/lieutenant.yml
@@ -16,9 +16,9 @@
   - Maintenance
   - External
   - Cryogenics
-  special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+  #special:
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant ] # Removed mindshields
 
 - type: startingGear
   id: LieutenantGear

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/Service/hospitalitydirector.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/Service/hospitalitydirector.yml
@@ -24,8 +24,8 @@
   - Chapel
   - Library
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+  #- !type:AddImplantSpecial
+  #  implants: [ MindShieldImplant ] # Removed mindshields
   - !type:AddComponentSpecial
     components:
     - type: CommandStaff

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -858,5 +858,10 @@ WeaponTaser: null
 # 2026-08-08 - xo & hd lockers
 LockerHeadOfPersonnelFilled: LockerExecutiveOfficerFilled
 
+# 2026-08-10 - removing mindshields
+CrateSecurityTrackingMindshieldImplants: CrateTrackingImplants
+CrateMindShieldImplants: CrateMedical
+MindshieldImplanter: null
+
 # TODO: When the RG-2 and its safe are ported over, uncomment the line below and add a timestamp.
 #GunSafeDisabler: GunSafePistolRg2


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
<!-- What did you change? -->

This PR effectively removes mindshields (and fake mindshields) from the game. Security/Command/CC roles no longer start with mindshields (except for deprecated jobs, which remain untouched), and them and their fake variant are no longer obtainable. Both have also been removed from the implant extractor dropdown. The implant crates found in the brig have been migrated to tracker implant crates (which contain five tracker implants). Mindshield crates have been replaced with empty Medical crates.

Command and Security jobs still can't be antags.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Well, because Tay asked me to. But there are a two main reasons why Tay asked me to:

1. Mindshields only exist gameplay-wise to serve as a balancing mechanism for conversion antagonists. We are definitely not going to have Revolutionaries enabled when Forky goes live, Blood Cult is slated for removal (#272), and we're not sure on Cosmic Cult. Therefore we are not going to have any conversion antagonists that need balancing out this way.
2. Mindshields being something implanted into Security/Command/Central Command, especially those three groups specifically, is a bit of a flavour fail concerning our themes. Those groups don't prop up NanoTrasen because they have a chip in their head telling them to do so, they do so for their own reasons, whether that's selfishness, political zealotry, systemic obedience, et cetera. In essence, they're cruel because capitalism is an ideology that rewards cruelty.

## Technical details
<!-- Summary of code changes for easier review. -->
Most of this PR was just commenting things out:
- Commented out the mindshields from all the jobs that had them.
- Commented out all the ways one could obtain a mindshield, fake mindshield, or a crate with mindshields in it.
- Marked the mindshield implanter and any crates containing it as `DO NOT MAP` and migrated them to versions without the mindshields.
- Commented out the mindshield and fake mindshield from the implants the implant extractor can remove.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Spawn in as a Command or Security job and put a security HUD on if you haven't got one already. You should not see the mindshield border on your icon.
2. Spawn in some ghost roles that previously had mindshields (ERT, CBURN, Deathsquad, visiting security/command). None of them should have mindshields now.
3. Open a cargo request console and look in the catalogue for a mindshield crate. It should not be present.
4. Get an implant extractor and look at the implant selection drop down. Neither the mindshield nor the fake mindshield should be present.
5. `forcemap` a map that had both an implanter crate and a mindshield crate (such as Serpentcrest). They should be a tracking implanter crate and an empty Medical crate instead.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

This is the only thing I can show that isn't just "thing that used to be there isn't there anymore".

<img width="463" height="154" alt="Screenshot_20260810_053023" src="https://github.com/user-attachments/assets/0c177750-b182-4341-ac71-2730a6ce3087" />

_(Two crates in Security migrated to versions that do not have mindshield implants.)_

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->

If you want to keep mindshields in the game, just revert this PR. If you want to remove mindshields too, but don't want any of our job restructuring stuff (#280, #285), you should remove them from HOS and HOP.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- remove: Mindshields and fake mindshields have been removed from the game. No roles spawn with one, and the items are unobtainable.
- tweak: The implanter crate has been replaced with a tracking implanter crate (swapping four mindshield implanters for an extra tracking implanter).