### PR TITLE
Viewcone Adjustments

### DIFF
--- a/Content.Client/DoAfter/DoAfterOverlay.cs
+++ b/Content.Client/DoAfter/DoAfterOverlay.cs
@@ -87,6 +87,9 @@ public sealed class DoAfterOverlay : Overlay
             if (xform.MapID != args.MapId)
                 continue;
 
+            if (!sprite.Visible) // ES, ported to Funky
+                continue;
+
             if (comp.DoAfters.Count == 0)
                 continue;
 

--- a/Content.Client/_ES/Viewcone/Overlays/ESViewconeConeOverlay.cs
+++ b/Content.Client/_ES/Viewcone/Overlays/ESViewconeConeOverlay.cs
@@ -56,7 +56,7 @@ public sealed partial class ESViewconeConeOverlay : Overlay
             // but its not really like its a huge inefficiency (this only has to happen twice per frame and its like a trivial event relay with no logic)
             // and i really dont want to make it stateful
             _coneAngle = _angle.GetModifiedViewconeAngle((uid, viewcone));
-            _coneFeather = viewcone.ConeFeather;
+            _coneFeather = _coneAngle <= 0f ? 0.01f : viewcone.ConeFeather; // semi-hack to make 0-angle viewcone look correct
             _coneIgnoreRadius = (viewcone.ConeIgnoreRadius - viewcone.ConeIgnoreFeather) * 50f;
             _coneIgnoreFeather = Math.Max(viewcone.ConeIgnoreFeather * 200f, 8f);
             _eyeEntity = (uid, eye, viewcone, xform);

--- a/Content.Shared/_ES/Viewcone/Components/ESViewconeModifierComponent.cs
+++ b/Content.Shared/_ES/Viewcone/Components/ESViewconeModifierComponent.cs
@@ -23,15 +23,16 @@ public record ESViewconeGetAngleModifierEvent : IInventoryRelayEvent
 {
     public SlotFlags TargetSlots => SlotFlags.HEAD | SlotFlags.EYES | SlotFlags.MASK;
 
-    private float _angleModifier;
+    private float? _angleModifier;
 
     public float GetAngleModifier()
     {
-        return _angleModifier;
+        return _angleModifier ?? 0f;
     }
 
+    // funky, takes the lowest value seen instead of stacking
     public void ModifyAngle(float angle)
     {
-        _angleModifier += angle;
+        _angleModifier = _angleModifier is { } current ? Math.Min(current, angle) : angle;
     }
 }

--- a/Content.Shared/_ES/Viewcone/ESViewconeAngleSystem.cs
+++ b/Content.Shared/_ES/Viewcone/ESViewconeAngleSystem.cs
@@ -1,4 +1,6 @@
 using Content.Shared._ES.Viewcone.Components;
+using Content.Shared._Funkystation.Viewcone;
+using Content.Shared.Disposal.Unit;
 using Content.Shared.Examine;
 using Content.Shared.Inventory;
 using Content.Shared.StatusEffectNew;
@@ -18,6 +20,9 @@ public sealed class ESViewconeAngleSystem : EntitySystem
         SubscribeLocalEvent<ESViewconeModifierComponent, ESViewconeGetAngleModifierEvent>(OnAngleModify);
         SubscribeLocalEvent<ESViewconeModifierComponent, InventoryRelayedEvent<ESViewconeGetAngleModifierEvent>>(OnAngleInventoryModify);
         SubscribeLocalEvent<ESViewconeModifierComponent, StatusEffectRelayedEvent<ESViewconeGetAngleModifierEvent>>(OnAngleStatusEffectModify);
+
+        SubscribeLocalEvent<ViewconeStorageBlindComponent, ESViewconeGetAngleModifierEvent>(OnConcealedAngle); // Funky
+        SubscribeLocalEvent<BeingDisposedComponent, ESViewconeGetAngleModifierEvent>(OnBeingDisposedAngle);
     }
 
     private void OnExamined(Entity<ESViewconeModifierComponent> ent, ref ExaminedEvent args)
@@ -43,6 +48,18 @@ public sealed class ESViewconeAngleSystem : EntitySystem
     private void OnAngleStatusEffectModify(Entity<ESViewconeModifierComponent> ent, ref StatusEffectRelayedEvent<ESViewconeGetAngleModifierEvent> args)
     {
         args.Args.ModifyAngle(ent.Comp.AngleModifier);
+    }
+
+    // Funky start
+    private void OnConcealedAngle(Entity<ViewconeStorageBlindComponent> ent, ref ESViewconeGetAngleModifierEvent args)
+    {
+        args.ModifyAngle(-360f);
+    }
+    // Funky end
+
+    private void OnBeingDisposedAngle(Entity<BeingDisposedComponent> ent, ref ESViewconeGetAngleModifierEvent args)
+    {
+        args.ModifyAngle(-360f);
     }
 
     /// <summary>

--- a/Content.Shared/_Funkystation/Viewcone/ViewconeStorageBlindComponent.cs
+++ b/Content.Shared/_Funkystation/Viewcone/ViewconeStorageBlindComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._Funkystation.Viewcone;
+
+// marker for when an entity is in storage like crates, and therefore MUST BE BLINDED!!!
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ViewconeStorageBlindComponent : Component;

--- a/Content.Shared/_Funkystation/Viewcone/ViewconeStorageBlindSystem.cs
+++ b/Content.Shared/_Funkystation/Viewcone/ViewconeStorageBlindSystem.cs
@@ -1,0 +1,60 @@
+﻿using Content.Shared.Storage.Components;
+using Robust.Shared.Containers;
+
+namespace Content.Shared._Funkystation.Viewcone;
+
+public sealed class ViewconeStorageBlindSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<EntityStorageComponent, StorageAfterCloseEvent>(OnStorageClosed);
+        SubscribeLocalEvent<EntityStorageComponent, StorageAfterOpenEvent>(OnStorageOpened);
+        SubscribeLocalEvent<EntityStorageComponent, EntInsertedIntoContainerMessage>(OnInserted);
+        SubscribeLocalEvent<EntityStorageComponent, EntRemovedFromContainerMessage>(OnRemoved);
+    }
+
+    // mark as blind when closed
+    private void OnStorageClosed(Entity<EntityStorageComponent> ent, ref StorageAfterCloseEvent args)
+    {
+        if (ent.Comp.Contents is not { } contents)
+            return;
+
+        foreach (var contained in contents.ContainedEntities)
+        {
+            EnsureComp<ViewconeStorageBlindComponent>(contained);
+        }
+    }
+
+    // unmark
+    private void OnStorageOpened(Entity<EntityStorageComponent> ent, ref StorageAfterOpenEvent args)
+    {
+        if (ent.Comp.Contents is not { } contents)
+            return;
+
+        foreach (var contained in contents.ContainedEntities)
+        {
+            RemComp<ViewconeStorageBlindComponent>(contained);
+        }
+    }
+
+    // in case something is somehow inserted while still closed
+    private void OnInserted(Entity<EntityStorageComponent> ent, ref EntInsertedIntoContainerMessage args)
+    {
+        if (ent.Comp.Contents is not { } contents || args.Container.ID != contents.ID)
+            return;
+
+        if (!ent.Comp.Open)
+            EnsureComp<ViewconeStorageBlindComponent>(args.Entity);
+    }
+
+    // and removes marker when something leaves storage
+    private void OnRemoved(Entity<EntityStorageComponent> ent, ref EntRemovedFromContainerMessage args)
+    {
+        if (ent.Comp.Contents is not { } contents || args.Container.ID != contents.ID)
+            return;
+
+        RemComp<ViewconeStorageBlindComponent>(args.Entity);
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
This PR takes some changes from ES, namely from these two PRs:
https://github.com/EphemeralSpace/ephemeral-space/pull/1909
https://github.com/EphemeralSpace/ephemeral-space/pull/2371

So DoAfters are now hidden if you're occluded, and you can't see anything if you're in a dispo chute.

Additionally, I made some changes of my own:
Viewcone impacting items like gas masks and helmets now just take the lower value rather than being adding up, preventing you from reaching nigh unplayable levels of viewcone reduction. I'm not honestly too sure about this change, but it seems *fair enough*. I GUESS.

Also, I added a system and component that blinds you if you're inside storage, i.e. a crate or locker. Yum dot com.
<!-- What did you change? -->

## Why / Balance
fkefkmkgmfsfgl
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
ViewconeStorageBlindComponent.cs is a marker
ViewconeStorageBlindSystem.cs manages that marker
<!-- Summary of code changes for easier review. -->

## Test plan
Open your atmos locker.
Put on a helmet and a gas mask. See how they don't compound on your vision.
Now shut yourself in the locker. See how you're blind. Contradictory!
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media

https://github.com/user-attachments/assets/60b259ef-4f40-4e1d-a8a6-84582b7ea6a1


<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->

## Changelog
:cl: Mirrorcult, EmoGarbage404, AraiMaia
- add: Being inside a trash chute, box or locker now puts your viewcone at 0.
- tweak: Viewcone-imparing items no longer compound, and just take the lowest angle.
- tweak: DoAfters are no longer visible if your sprite is occluded.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
