### PR TITLE
Syndicate Hardsuit Lighting Amp

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -589,7 +589,6 @@
     energy: 3
 
 #ANTAG HARDSUITS
-# Funky Amped the radius and energy of syndicate suit headlights.
 #Blood-red Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
@@ -601,7 +600,7 @@
     sprite: Clothing/Head/Hardsuits/syndicate.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndicate.rsi
-  - type: PointLight
+  - type: PointLight # Funky Station - Increased the radius of syndicate suit headlights 3>5. Energy is specified but unchanged from ClothingHeadSuitWithLightBase.
     radius: 5
     energy: 2
     color: green
@@ -630,7 +629,7 @@
     sprite: Clothing/Head/Hardsuits/syndiemedic.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndiemedic.rsi
-  - type: PointLight
+  - type: PointLight # Funky Station - Increased the radius of syndicate suit headlights 3>5. Energy is specified but unchanged from ClothingHeadSuitWithLightBase.
     radius: 5
     energy: 2
     color: green
@@ -656,7 +655,7 @@
     sprite: Clothing/Head/Hardsuits/syndieelite.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndieelite.rsi
-  - type: PointLight
+  - type: PointLight # Funky Station - Increased the radius of syndicate suit headlights 3>5. Energy is specified but unchanged from ClothingHeadSuitWithLightBase.
     radius: 5
     energy: 2
     color: red
@@ -690,8 +689,8 @@
     sprite: Clothing/Head/Hardsuits/syndiecommander.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndiecommander.rsi
-  - type: PointLight
-    radius: 5
+  - type: PointLight # Funky Station - Increased the radius of syndicate suit headlights 3>5. Energy is specified but unchanged from ClothingHeadSuitWithLightBase.
+    radius: 5 
     energy: 2
     color: green
   - type: PressureProtection

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -589,6 +589,7 @@
     energy: 3
 
 #ANTAG HARDSUITS
+# Funky Amped the radius and energy of syndicate suit headlights.
 #Blood-red Hardsuit
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
@@ -601,6 +602,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndicate.rsi
   - type: PointLight
+    radius: 5
+    energy: 2
     color: green
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -628,6 +631,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndiemedic.rsi
   - type: PointLight
+    radius: 5
+    energy: 2
     color: green
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -652,6 +657,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndieelite.rsi
   - type: PointLight
+    radius: 5
+    energy: 2
     color: red
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -684,6 +691,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndiecommander.rsi
   - type: PointLight
+    radius: 5
+    energy: 2
     color: green
   - type: PressureProtection
     highPressureMultiplier: 0.08


### PR DESCRIPTION
## About the PR
Amped syndicate hardsuits helmets to have better lights.
Duplicate PR because i'm a moron and deleted the original branch by accident.
## Why / Balance
The lights were terrible and pretty much only added aura. Now they add more aura AND are usable lights. They are now on par (slightly worse due to the colouration) with the paramedic voidsuit.

## Technical details
Couple lines YAML to increase radius of the helmet lights.

## Test plan
Changed light values, spawned hardsuits, tested lights.

## Media
<img width="1089" height="365" alt="syndilights" src="https://github.com/user-attachments/assets/0f7ef5a7-fa99-4ce0-b8c8-262437c145e3" />

## Requirements
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.

## License
MIT

## Changelog
:cl: Sere
- tweak: Increased lighting radius for syndicate hardsuits (that had lights to begin with).
