### PR TITLE
Radio's TC rebalance but for real this time.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -2,10 +2,10 @@
   parent: [ CrateSyndicate, StorePresetUplink, BaseSyndicateContraband ]
   id: CrateSyndicateSurplusBundle
   name: Syndicate surplus crate
-  description: Contains 50 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
+  description: Contains 225 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
   components:
     - type: SurplusBundle
-      totalPrice: 50
+      totalPrice: 225 # Funky Change 50 - 225. Changed to match the new 100TC traitor budget.
 
 - type: entity
   parent: CrateSyndicate

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -146,9 +146,9 @@
   productEntity: WeaponRevolverPythonAP
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 9 # Funky Change 2 -> 9. Changed to match new base price.
   cost:
-    Telecrystal: 4
+    Telecrystal: 18 # Funky Change 4 -> 18. Fixed price for new budget. Also slight buff, not really better than a viper (14tc) outside of assassinating specific armored targets. Decided to make the same price as Cobra.
   categories:
   - UplinkWeaponry
 
@@ -244,11 +244,11 @@
   description: uplink-gloves-knuckleduster-desc
   icon: { sprite: Clothing/Hands/Gloves/KnuckleDusters/syndicateknuckleduster.rsi, state: syndicateknuckleduster }
   productEntity: ClothingHandsKnuckleDustersSyndicate
-  discountCategory: veryRareDiscounts
-  discountDownTo:
-    Telecrystal: 5
+ # discountCategory: veryRareDiscounts # Funky Change. Commented out because I don't think the dusters being cheaper than they already are would do much.
+ # discountDownTo:
+ #   Telecrystal: 5
   cost:
-    Telecrystal: 15
+    Telecrystal: 10 # Funky Change 15 -> 10. Buffed. The dusters do 8 blunt and 8 pierce. meanwhile the energy dagger which is only 10 TC does 10 slash and 10 heat, while also being a disguised weapon.
   categories:
   - UplinkWeaponry
 
@@ -307,9 +307,9 @@
   productEntity: BriefcaseWeaponHushpupFilled
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 30
+    Telecrystal: 20 # Funky Change 30 -> 20. To match the new standard price of 40 TC.
   cost:
-    Telecrystal: 50
+    Telecrystal: 40 # Funky Change 50 -> 40. Buff. The Hushpup is pretty weak in my experience. Lower price to match the Esword should make it a bit more viable.
   categories:
   - UplinkWeaponry
 
@@ -321,9 +321,9 @@
   productEntity: BriefcaseWeaponC20Filled
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 45
+    Telecrystal: 35 # Funky Change 45 -> 35. To match the new base price.
   cost:
-    Telecrystal: 70
+    Telecrystal: 60 # Funky Change 70 -> 60. Buff. These guns don't come with backup ammo anymore, so I'm reducing their price a little to account for the fact that traitors will need to buy that stuff.
   categories:
   - UplinkWeaponry
   conditions:
@@ -359,9 +359,9 @@
   productEntity: BriefcaseWeaponBulldogFilled
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 45
+    Telecrystal: 45 # Funky Change 45 -> 35. To match the new base price.
   cost:
-    Telecrystal: 70
+    Telecrystal: 60 # Funky Change 70 -> 60. Buff. These guns don't come with backup ammo anymore, so I'm reducing their price a little to account for the fact that traitors will need to buy that stuff.
   categories:
   - UplinkWeaponry
   conditions:
@@ -507,9 +507,9 @@
   productEntity: SingularityGrenade
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 20
+    Telecrystal: 5 # Funky Change 20 -> 5. To match the new base price.
   cost:
-    Telecrystal: 30
+    Telecrystal: 15 # Funky Change 30 -> 15. Buff. Have you ever seen anyone use this outside of finding it in a surplus?
   categories:
     - UplinkDisruption
 
@@ -538,9 +538,9 @@
   productEntity: C4
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 15
+    Telecrystal: 2 # Funky Change. To match new base price.
   cost:
-    Telecrystal: 25
+    Telecrystal: 8 # Funky Change 25 -> 8. Buff? I don't know why this was set as 25 TC. Made 8 TC for parity with old funky.
   categories:
   - UplinkExplosives
 
@@ -569,9 +569,9 @@
   productEntity: ClothingBackpackDuffelSyndicateC4tBundle
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 40
+    Telecrystal: 28 # Funky change 40 -> 28. To match new base price.
   cost:
-    Telecrystal: 60 #you're buying bulk so its a 25% discount, so no additional random discount over it
+    Telecrystal: 48 # Funky Change 60 -> 48. Buff. Made the bulk-buy discount more substantial.
   categories:
   - UplinkExplosives
 
@@ -720,16 +720,16 @@
   - UplinkAmmo
 
 
-# For the Estoc
-- type: listing
-  id: UplinkEstocAmmo
-  name: uplink-estoc-ammo-name
-  description: uplink-estoc-ammo-desc
-  productEntity: MagazineRifle
-  cost:
-    Telecrystal: 12
-  categories:
-  - UplinkAmmo
+# For the Estoc # Note: Funky. Estoc is now .50 AE rather than .20 rifle, and the M-90 also doesn't exist. I commented this out due to that.
+#- type: listing
+#  id: UplinkEstocAmmo
+#  name: uplink-estoc-ammo-name
+#  description: uplink-estoc-ammo-desc
+#  productEntity: MagazineRifle
+#  cost:
+#    Telecrystal: 12
+#  categories:
+#  - UplinkAmmo
 
 # Funky - For the Python
 - type: listing
@@ -739,18 +739,18 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi, state: icon }
   productEntity: SpeedLoaderMagnumAP
   cost:
-    Telecrystal: 3
+    Telecrystal: 8 # Funky Change 3 -> 8. Fixed for new budget.
   categories:
   - UplinkAmmo
 
-# For the mosin
+# For the mosin # Note: Mosin isn't in the uplink as of writing this.
 - type: listing
   id: UplinkMosinAmmo
   name: uplink-mosin-ammo-name
   description: uplink-mosin-ammo-desc
   productEntity: MagazineBoxLightRifle
   cost:
-    Telecrystal: 1
+    Telecrystal: 8 # Funky Change 1 -> 8. Budget Fix. Changed to match the .60 AMR ammo box price -2. shouldn't be too expensive for when mosin is added to uplink, but should be pricy enough to limit L6 SAW ammo.
   categories:
   - UplinkAmmo
 
@@ -868,9 +868,9 @@
   productEntity: MedkitCombatFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 5
+    Telecrystal: 14 # Funky Change 5 -> 12. To match the item's new base price.
   cost:
-    Telecrystal: 15
+    Telecrystal: 23 # Funky Change 15 -> 23. Nerf. It's a very strong healing item. I would have set it to 25 for parity with old funky but omnizine is better now, so it's a bit cheaper than 25tc since it has actual competition now.
   categories:
   - UplinkChemicals
 
@@ -881,35 +881,35 @@
   productEntity: CombatMedipen
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 10
+    Telecrystal: 6 # Funky Change. To match the item's new base price.
   cost:
-    Telecrystal: 20
+    Telecrystal: 12 # Funky Change 20 -> 12. Buff. Always thought this item was really weak in the grand scheme of things, definetly not better than a combat medkit at least. It's more powerful now that omnizene is good, but it's still only a single-use one-time heal, compared to the medkit which can last longer.
   categories:
   - UplinkChemicals
 
 - type: listing
-  id: UplinkStimpack
+  id: UplinkStimpack # Pretty sure this is the Hyperzine Injector?
   name: uplink-stimpack-name
   description: uplink-stimpack-desc
   productEntity: Stimpack
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 15
+    Telecrystal: 5 # Funky Change. To match the new base price.
   cost:
-    Telecrystal: 25
+    Telecrystal: 15 # Funky Change 25 -> 15. Buff. Stunmeta is dead on funky, so the "recover from stuns faster" utility is less prevelant. 25 TC just felt too expensive and like people would rarely ever buy the item.
   categories:
   - UplinkChemicals
 
 - type: listing
-  id: UplinkStimkit
+  id: UplinkStimkit # Pretty sure this one is the hyperzine microinjector kit.
   name: uplink-stimkit-name
   description: uplink-stimkit-desc
   productEntity: StimkitFilled
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 20
+    Telecrystal: 15 # Funky Change. To match the new base price.
   cost:
-    Telecrystal: 40
+    Telecrystal: 30 # Funky Change. Buff. Changed to match the injector, except you get 33% better value (3 minutes of total hyperzine, versus the 2 minutes you would get with buying two normal injectors)
   categories:
   - UplinkChemicals
 
@@ -919,7 +919,7 @@
   description: uplink-cigarettes-desc
   productEntity: CigPackSyndicate
   cost:
-    Telecrystal: 20
+    Telecrystal: 5 # Funky Change. Buff. You can't grind cigs anymore, so you have to smoke these for the actual benefit, which can be hard to do and slow.
   categories:
   - UplinkChemicals
 
@@ -947,7 +947,7 @@
 
 # Deception
 - type: listing
-  id: UplinkSyndicateIDCard
+  id: UplinkSyndicateIDCard # This is the non-agent one.
   name: uplink-syndicate-id-card-name
   description: uplink-syndicate-id-card-desc
   productEntity: SyndicateIDCard
@@ -963,9 +963,9 @@
   productEntity: AgentIDCard
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 15
+    Telecrystal: 9 # Funky Change. To match the new base price.
   cost:
-    Telecrystal: 30
+    Telecrystal: 15 # Funky Change 30 -> 15. Buff. This item does not feel like it's worth the same price as an access breaker or emag. Changed to 15 TC for parity with old funky.
   categories:
   - UplinkDeception
 
@@ -1001,11 +1001,11 @@
   description: uplink-encryption-key-desc
   icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: synd_label }
   productEntity: BoxEncryptionKeySyndie # Two for the price of one
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 10
+ # discountCategory: usualDiscounts # Funky. Commenting this part out because it's 5 TC now, so the discount is pretty insubstantial and sauceless.
+ # discountDownTo:
+ #   Telecrystal: 10
   cost:
-    Telecrystal: 15
+    Telecrystal: 5 # Funky Change 15 -> 5. Buff. Syndies actually communicating is already rare. Plus the channel is so easy to compromise that it makes the item inherently risky. Price for parity with old funky.
   categories:
   - UplinkDeception
 
@@ -1016,7 +1016,7 @@
   icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: ai_label }
   productEntity: EncryptionKeyBinarySyndicate
   cost:
-    Telecrystal: 10
+    Telecrystal: 5 # Funky Change 10 -> 5. Buff. Parity with old funky and I don't think this is that strong without relying on other expensive strategies.
   categories:
   - UplinkDeception
 
@@ -1026,7 +1026,7 @@
   description: uplink-cyberpen-desc
   productEntity: CyberPen
   cost:
-    Telecrystal: 3
+    Telecrystal: 5 # Funky Change 3 -> 5. Price fix/Parity. The pen isn't weak, so I doubt the 3TC price was an intentional buff.
   categories:
   - UplinkDeception
 
@@ -1036,7 +1036,7 @@
   description: uplink-decoy-disk-desc
   productEntity: NukeDiskFake
   cost:
-    Telecrystal: 1
+    Telecrystal: 2 # Funky Change 1 -> 2. Price Fix. 2TC for parity.
   categories:
   - UplinkDeception
 
@@ -1047,9 +1047,9 @@
   productEntity: BriefcaseSyndieLobbyingBundleFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 20
+    Telecrystal: 15 # Funky, Changed to match new base price.
   cost:
-    Telecrystal: 30
+    Telecrystal: 25 # Funky Change 30 -> 25. Bribing people is fun! Made it slightly cheaper to allow this more.
   categories:
     - UplinkDeception
 
@@ -1135,9 +1135,9 @@
   productEntity: RadioJammer
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 15
+    Telecrystal: 5 # Funky Change. So the discount matches the item's new base price.
   cost:
-    Telecrystal: 25
+    Telecrystal: 10 # Funky Change 25 -> 10. Buff. Never found this item very useful. If you're kidnapping a target, just take their headset off and turn off their coords, it's free.
   categories:
   - UplinkDisruption
 
@@ -1239,7 +1239,7 @@
   description: uplink-travel-camera-desc
   productEntity: TravelCamera
   cost:
-    Telecrystal: 1
+    Telecrystal: 10 # Funky Change 1 -> 10. Price Fix. It's a reusable disguised flash which supposedly exists in funky (as a lantern rather than camera) but I've never seen it used. Price kept at 10 TC to match the lantern.
   categories:
   - UplinkDeception
 
@@ -1618,9 +1618,9 @@
   productEntity: RadioImplanter
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 4 # Funky Change 1 -> 4. Changed to match item's new base price.
   cost:
-    Telecrystal: 2
+    Telecrystal: 8 # Funky Change 2 -> 8. Price Fix. Minor buff compared to old forky (was 10 tc) due to the fact that traitors don't communicate that often and that the syndicate radio channel is so easy to compromise from other traitors with keys getting searched by sec.
   categories:
   - UplinkImplants
 
@@ -1687,7 +1687,7 @@
   icon: { sprite: /Textures/Objects/Devices/communication.rsi, state: old-radio }
   productEntity: UplinkImplanter
   cost:
-    Telecrystal: 20
+    Telecrystal: 10 # Funky Change 20 -> 10. Buff. Killing 20% of your budget for a bit of extra safety doesn't seem worth it at all.
   categories:
   - UplinkImplants
   conditions:
@@ -1785,9 +1785,9 @@
   productEntity: ClothingShoesChameleonNoSlips
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 1
+    Telecrystal: 7 # Funky Change 1 -> 7. Changed to match new base price.
   cost:
-    Telecrystal: 2
+    Telecrystal: 15 # Funky Change 2 -> 15. Budget Fix. Changed to match the blood-red magboots.
   categories:
   - UplinkWearables
 
@@ -1837,7 +1837,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Suits/eva_syndicate.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateEVABundle
   cost:
-    Telecrystal: 8
+    Telecrystal: 5 # Funky Change 8 -> 5. Buff. The suit is signficantly crappier than it was on the old codebase, with 20% slowdown and no resistances, so for a suit that instantly gives you away as a syndie it should be cheaper.
   categories:
   - UplinkWearables
 
@@ -1863,9 +1863,9 @@
   productEntity: ClothingBackpackDuffelSyndicateHardsuitBundle
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 45
+    Telecrystal: 30 # Funky Change 45 -> 30. Changed to match new base price.
   cost:
-    Telecrystal: 50
+    Telecrystal: 40 # Funky Change 50 -> 40. Buff. The hardsuit is far, far from optimal for traitors, so I think it would be fun if it was easier to work with by giving traitors a bigger budget when wanting to use the suit.
   categories:
   - UplinkWearables
 
@@ -2114,7 +2114,7 @@
   icon: { sprite: /Textures/Objects/Tools/Decoys/operative_decoy.rsi, state: folded }
   productEntity: ClothingBackpackDuffelSyndicateDecoyKitFilled
   cost:
-    Telecrystal: 4
+    Telecrystal: 18 # Funky Change 4 -> 18. Price Fix. Somewhat useful, but not that much. (Mainly due to funky not using the commander or medic nukie suit.) Price should be high enough that the item shouldn't be spammable.
   categories:
   - UplinkPointless
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -148,7 +148,7 @@
   discountDownTo:
     Telecrystal: 9 # Funky Change 2 -> 9. Changed to match new base price.
   cost:
-    Telecrystal: 18 # Funky Change 4 -> 18. Fixed price for new budget. Also slight buff, not really better than a viper (14tc) outside of assassinating specific armored targets. Decided to make the same price as Cobra.
+    Telecrystal: 17 # Funky Change 4 -> 17. Fixed price for new budget. Also slight buff, not really better than a viper (14tc) outside of assassinating specific armored targets. Decided to make the same price as Cobra.
   categories:
   - UplinkWeaponry
 
@@ -162,7 +162,7 @@
   discountDownTo:
     Telecrystal: 10
   cost:
-    Telecrystal: 18
+    Telecrystal: 20 # Funky Change 18 -> 20. Decided to raise price slightly to account for the fact that its ammo is now down to 5TC.
   categories:
   - UplinkWeaponry
 
@@ -309,7 +309,7 @@
   discountDownTo:
     Telecrystal: 20 # Funky Change 30 -> 20. To match the new standard price of 40 TC.
   cost:
-    Telecrystal: 40 # Funky Change 50 -> 40. Buff. The Hushpup is pretty weak in my experience. Lower price to match the Esword should make it a bit more viable.
+    Telecrystal: 40 # Funky Change 50 -> 40. Buff. The item doesn't come with any ammo, meaning that syndies will need to buy more or find more to reload it.
   categories:
   - UplinkWeaponry
 
@@ -434,7 +434,7 @@
   discountDownTo:
     Telecrystal: 70
   cost:
-    Telecrystal: 85
+    Telecrystal: 95 # Funky Change 85 -> 95. This one comes with more ammo for nukies, so it should be more expensive than traitor lake.
   categories:
   - UplinkWeaponry
   conditions:
@@ -538,7 +538,7 @@
   productEntity: C4
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 2 # Funky Change. To match new base price.
+    Telecrystal: 2 # Funky Change 15 -> 2. To match new base price.
   cost:
     Telecrystal: 8 # Funky Change 25 -> 8. Buff? I don't know why this was set as 25 TC. Made 8 TC for parity with old funky.
   categories:
@@ -680,7 +680,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/smg_mag.rsi, state: red-icon }
   productEntity: MagazinePistolSubMachineGun
   cost:
-    Telecrystal: 7
+    Telecrystal: 5 # Funky Change 7 -> 5. Changed to make several ammo items have more simple and rounder pricing. (mostly 5s and 10s)
   categories:
   - UplinkAmmo
 
@@ -715,7 +715,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/CaselessRifle/caseless_pistol_mag.rsi, state: red-icon }
   productEntity: MagazinePistolCaselessRifle
   cost:
-    Telecrystal: 6
+    Telecrystal: 5 # Funky Change 6 -> 5. Changed to make several ammo items have more simple and rounder pricing. (mostly 5s and 10s)
   categories:
   - UplinkAmmo
 
@@ -739,7 +739,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi, state: icon }
   productEntity: SpeedLoaderMagnumAP
   cost:
-    Telecrystal: 8 # Funky Change 3 -> 8. Fixed for new budget.
+    Telecrystal: 10 # Funky Change 3 -> 10. Fixed for new budget. Changed to make several ammo items have more simple and rounder pricing. (mostly 5s and 10s)
   categories:
   - UplinkAmmo
 
@@ -750,7 +750,7 @@
   description: uplink-mosin-ammo-desc
   productEntity: MagazineBoxLightRifle
   cost:
-    Telecrystal: 8 # Funky Change 1 -> 8. Budget Fix. Changed to match the .60 AMR ammo box price -2. shouldn't be too expensive for when mosin is added to uplink, but should be pricy enough to limit L6 SAW ammo.
+    Telecrystal: 5 # Funky Change 1 -> 5. Budget Fix. Changed to make several ammo item have more simple and rounder pricing. (mostly 5s and 10s)
   categories:
   - UplinkAmmo
 
@@ -881,7 +881,7 @@
   productEntity: CombatMedipen
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 6 # Funky Change. To match the item's new base price.
+    Telecrystal: 6 # Funky Change 10 -> 6. To match the item's new base price.
   cost:
     Telecrystal: 12 # Funky Change 20 -> 12. Buff. Always thought this item was really weak in the grand scheme of things, definetly not better than a combat medkit at least. It's more powerful now that omnizene is good, but it's still only a single-use one-time heal, compared to the medkit which can last longer.
   categories:
@@ -894,7 +894,7 @@
   productEntity: Stimpack
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 5 # Funky Change. To match the new base price.
+    Telecrystal: 5 # Funky Change 15 -> 5. To match the new base price.
   cost:
     Telecrystal: 15 # Funky Change 25 -> 15. Buff. Stunmeta is dead on funky, so the "recover from stuns faster" utility is less prevelant. 25 TC just felt too expensive and like people would rarely ever buy the item.
   categories:
@@ -907,9 +907,9 @@
   productEntity: StimkitFilled
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 15 # Funky Change. To match the new base price.
+    Telecrystal: 18 # Funky Change 20 -> 18. To match the new base price.
   cost:
-    Telecrystal: 30 # Funky Change. Buff. Changed to match the injector, except you get 33% better value (3 minutes of total hyperzine, versus the 2 minutes you would get with buying two normal injectors)
+    Telecrystal: 35 # Funky Change. Buff. Changed to be closer to the new injector price, but with a bulk-buy discount.
   categories:
   - UplinkChemicals
 
@@ -919,7 +919,7 @@
   description: uplink-cigarettes-desc
   productEntity: CigPackSyndicate
   cost:
-    Telecrystal: 5 # Funky Change. Buff. You can't grind cigs anymore, so you have to smoke these for the actual benefit, which can be hard to do and slow.
+    Telecrystal: 5 # Funky Change 20 -> 5. Buff. You can't grind cigs anymore, so you have to smoke these for the actual benefit, which can be hard to do and slow.
   categories:
   - UplinkChemicals
 
@@ -963,7 +963,7 @@
   productEntity: AgentIDCard
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 9 # Funky Change. To match the new base price.
+    Telecrystal: 9 # Funky Change 15 -> 9. To match the new base price.
   cost:
     Telecrystal: 15 # Funky Change 30 -> 15. Buff. This item does not feel like it's worth the same price as an access breaker or emag. Changed to 15 TC for parity with old funky.
   categories:
@@ -1047,7 +1047,7 @@
   productEntity: BriefcaseSyndieLobbyingBundleFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 15 # Funky, Changed to match new base price.
+    Telecrystal: 15 # Funky 20 -> 15, Changed to match new base price.
   cost:
     Telecrystal: 25 # Funky Change 30 -> 25. Bribing people is fun! Made it slightly cheaper to allow this more.
   categories:
@@ -1135,7 +1135,7 @@
   productEntity: RadioJammer
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 5 # Funky Change. So the discount matches the item's new base price.
+    Telecrystal: 5 # Funky Change 15 -> 5. So the discount matches the item's new base price.
   cost:
     Telecrystal: 10 # Funky Change 25 -> 10. Buff. Never found this item very useful. If you're kidnapping a target, just take their headset off and turn off their coords, it's free.
   categories:
@@ -1239,7 +1239,7 @@
   description: uplink-travel-camera-desc
   productEntity: TravelCamera
   cost:
-    Telecrystal: 10 # Funky Change 1 -> 10. Price Fix. It's a reusable disguised flash which supposedly exists in funky (as a lantern rather than camera) but I've never seen it used. Price kept at 10 TC to match the lantern.
+    Telecrystal: 10 # Funky Change 1 -> 10. Price Fix. It's a reusable disguised flash which existed in old funky (as a lantern rather than camera) but I've never seen it used. Price kept at 10 TC to match the lantern.
   categories:
   - UplinkDeception
 
@@ -1798,9 +1798,9 @@
   productEntity: ClothingOuterVestWeb
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 15
+    Telecrystal: 10 # Funky Change 15 -> 10. Changed to match new base price.
   cost:
-    Telecrystal: 20
+    Telecrystal: 15 # Funky Change 20 -> 15. Buff. Changed for parity with old funky, plus the fact that sec uses mostly heat damage weapons now means this item is going to be quite weak.
   categories:
   - UplinkWearables
 
@@ -1811,9 +1811,9 @@
   productEntity: ClothingOuterVestWebElite
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 25
+    Telecrystal: 20 # Funky Change 25 -> 20. Changed to match new base price.
   cost:
-    Telecrystal: 30
+    Telecrystal: 25 # Funky Change 30 -> 25. Buff. Changed for parity with old funky.
   categories:
   - UplinkWearables
 

--- a/Resources/Prototypes/_Funkystation/Store/uplink_catalog.yml
+++ b/Resources/Prototypes/_Funkystation/Store/uplink_catalog.yml
@@ -5,7 +5,7 @@
   description: uplink-pistol-wyvern-desc
   productEntity: WeaponPistolWyvern
   cost:
-    Telecrystal: 8
+    Telecrystal: 30 # Funky Change 8 -> 30. Fixed for new budget and buffed to 30 rather than 40 because this thing seemed to never get used.
   categories:
   - UplinkWeaponry
 
@@ -17,7 +17,7 @@
   icon: { sprite: /Textures/_Funkystation/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag_50.rsi, state: green-icon }
   productEntity: MagazinePistolLargeUranium
   cost:
-    Telecrystal: 2
+    Telecrystal: 7 # Funky Change 2 -> 7. Budget fix. Changed to match the .25 caseless mags +1.
   categories:
   - UplinkAmmo
   conditions:
@@ -33,7 +33,7 @@
   icon: { sprite: /Textures/_Funkystation/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag_50.rsi, state: base }
   productEntity: MagazinePistolLarge
   cost:
-    Telecrystal: 2
+    Telecrystal: 6 # Funky Change 2 -> 6. Budget Fix. Changed to match the .25 caseless mags.
   categories:
   - UplinkAmmo
 
@@ -43,11 +43,14 @@
   name: uplink-estoc-bundle-name
   description: uplink-estoc-bundle-desc
   productEntity: BriefcaseWeaponEstocFilled
+  discountCategory: veryRareDiscounts
+  discountDownTo:
+    Telecrystal: 45 # Funky. I manually added the discount, same price as C-20r. Check if I did it right in the draft please thanks.
   cost:
-    Telecrystal: 15
+    Telecrystal: 70 # Funky Change 15 -> 70. Budget Fix. Changed to match C-20r (noting that the estoc comes with 3 spare mags, while c20 and bulldog come with zero spares)
   categories:
   - UplinkWeaponry
-  
+
 # For the Estoc
 - type: listing
   id: UplinkRifle50Magazine
@@ -56,10 +59,10 @@
   icon: { sprite: /Textures/_Funkystation/Objects/Weapons/Guns/Ammunition/Magazine/Rifle/rifle_mag_50.rsi, state: base }
   productEntity: MagazineRifle50
   cost:
-    Telecrystal: 3
+    Telecrystal: 7 # Funky Change 3 -> 7. Budget Fix. Changed to match the .35 auto SMG mags.
   categories:
   - UplinkAmmo
-  
+
 - type: listing
   id: UplinkRifle50MagazineIncendiary
   name: uplink-rifle-magazine-50-incendiary-name
@@ -67,7 +70,7 @@
   icon: { sprite: /Textures/_Funkystation/Objects/Weapons/Guns/Ammunition/Magazine/Rifle/rifle_mag_50.rsi, state: red-icon }
   productEntity: MagazineRifle50Incendiary
   cost:
-    Telecrystal: 4
+    Telecrystal: 8 # Funky Change 4 -> 8. Budget Fix. Changed to match the .35 auto SMG mags, +1.
   categories:
   - UplinkAmmo
 
@@ -84,4 +87,3 @@
     Telecrystal: 20
   categories:
   - UplinkDisruption
-  

--- a/Resources/Prototypes/_Funkystation/Store/uplink_catalog.yml
+++ b/Resources/Prototypes/_Funkystation/Store/uplink_catalog.yml
@@ -17,7 +17,7 @@
   icon: { sprite: /Textures/_Funkystation/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag_50.rsi, state: green-icon }
   productEntity: MagazinePistolLargeUranium
   cost:
-    Telecrystal: 7 # Funky Change 2 -> 7. Budget fix. Changed to match the .25 caseless mags +1.
+    Telecrystal: 6 # Funky Change 2 -> 6. Budget fix. Changed to match the (new price of) .25 caseless mags +1.
   categories:
   - UplinkAmmo
   conditions:
@@ -33,7 +33,7 @@
   icon: { sprite: /Textures/_Funkystation/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag_50.rsi, state: base }
   productEntity: MagazinePistolLarge
   cost:
-    Telecrystal: 6 # Funky Change 2 -> 6. Budget Fix. Changed to match the .25 caseless mags.
+    Telecrystal: 5 # Funky Change 2 -> 5. Budget Fix. Changed to match the (new price of) .25 caseless mags.
   categories:
   - UplinkAmmo
 
@@ -45,11 +45,16 @@
   productEntity: BriefcaseWeaponEstocFilled
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 45 # Funky. I manually added the discount, same price as C-20r. Check if I did it right in the draft please thanks.
+    Telecrystal: 45 # Funky. I manually added this discount, same price as C-20r.
   cost:
-    Telecrystal: 70 # Funky Change 15 -> 70. Budget Fix. Changed to match C-20r (noting that the estoc comes with 3 spare mags, while c20 and bulldog come with zero spares)
+    Telecrystal: 70 # Funky Change 15 -> 70. Budget Fix. LOWER THIS TO 60 WHEN ITS SPARE MAGS GET REMOVED TO MATCH OTHER GUNS!
   categories:
   - UplinkWeaponry
+  conditions:
+  - !type:StoreWhitelistCondition # Funky Change. So that there isn't two different estocs in the nukie uplink.
+    blacklist:
+      tags:
+      - NukeOpsUplink
 
 # For the Estoc
 - type: listing
@@ -59,7 +64,7 @@
   icon: { sprite: /Textures/_Funkystation/Objects/Weapons/Guns/Ammunition/Magazine/Rifle/rifle_mag_50.rsi, state: base }
   productEntity: MagazineRifle50
   cost:
-    Telecrystal: 7 # Funky Change 3 -> 7. Budget Fix. Changed to match the .35 auto SMG mags.
+    Telecrystal: 5 # Funky Change 3 -> 5. Budget Fix. Changed to match the (new price of) .35 auto SMG mags.
   categories:
   - UplinkAmmo
 
@@ -70,7 +75,7 @@
   icon: { sprite: /Textures/_Funkystation/Objects/Weapons/Guns/Ammunition/Magazine/Rifle/rifle_mag_50.rsi, state: red-icon }
   productEntity: MagazineRifle50Incendiary
   cost:
-    Telecrystal: 8 # Funky Change 4 -> 8. Budget Fix. Changed to match the .35 auto SMG mags, +1.
+    Telecrystal: 6 # Funky Change 4 -> 6. Budget Fix. Changed to match the (new price of) .35 auto SMG mags, +1.
   categories:
   - UplinkAmmo
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
<!-- What did you change? -->
Fixed several items that were still using the old pricing according to the 20TC wizden budget to now use the 100TC funky budget.
Rebalanced the pricing of several items to buff several of them and nerf one or two. (didn't really touch nukie uplink outside of fixing the double estoc)
Changed most ammo to now cost either 5 or 10 TC.
Reduced price of the two "big guns" to 60 TC to account for needing to buy ammo.
Commented out a redundant/useless magazine item.
Fixed some small things like the nukie uplink having two different identical estoc bundles and the Surplus crate only having 50TC worth of stuff in it. (changed to 225 TC in it)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
There were numerous issues with the prices of items so my main goal was to fix those.
After that, I started rebalancing some items that were either not very viable or that I never saw used, like the knuckle dusters, in order to make them more in line with the other items and some items were adjusted in the hopes that they would allow for easier execution of fun strategies. 
Also had to reduce price on guns now that they don't come with bundles that have ammo in them.
Ammo prices were changed so that the majority of the time your ammo costs will be divisible by 5 rather than being some kind of random uncomfortable number. 
Fixed minor errors such as the double Estoc for obvious reasons.
## Technical details
<!-- Summary of code changes for easier review. -->
a lot of .yml editing.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Spawn uplink.
Peruse the store.
Buy some items.
Check there aren't two estocs in the nukie uplink.
Buy a surplus crate and make sure it contains the correct amount of items.
Profit.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->
Many Uplink items have had their price changed. You can probably just change any that you don't like.
## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- fix: Several Uplink items are now correctly priced for the 100TC budget.
- fix: A certain Uplink item that was ammunition for a gun that no longer used that ammo type has been commented out.
- tweak: Many Traitor Uplink items have had their price rebalanced, buffing many of them to be cheaper due to being weak or rarely used items.