### PR TITLE
Updated Captain role timers

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -21,21 +21,18 @@
       #time: 4h
       time: 10h # Funky
     - !type:DepartmentTimeRequirement
-      department: InternalAffairs
-      time: 4h
+      department: InternalAffairs # Funky
+      time: 5h
     - !type:DepartmentTimeRequirement
-      department: Cargo
-      time: 4h
+      department: Cargo # Funky
+      time: 5h
     - !type:DepartmentTimeRequirement
-      department: Service
-      time: 4h
+      department: Service # Funky
+      time: 5h
     - !type:DepartmentTimeRequirement
       department: Command
       #time: 4h
       time: 20h # Funky
-    - !type:OverallPlaytimeRequirement
-      time: 40h # Funky
-    # TODO: Add a time requirement for Internal Affairs when that gets added
   #weight: 20 # Funky - Weighting all jobs equally now
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -19,10 +19,10 @@
     - !type:DepartmentTimeRequirement
       department: Security
       #time: 4h
-      time: 10h # Funky
+      time: 5h # Funky
     - !type:DepartmentTimeRequirement
       department: InternalAffairs # Funky
-      time: 5h
+      time: 10h
     - !type:DepartmentTimeRequirement
       department: Cargo # Funky
       time: 5h


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
<!-- What did you change? -->

Initially I was going to add Internal Affairs hours to the Captain role times. Turns out they're already in there but it and some other departments had a four hour requirement (like WizDen's timers) when five hours is the standard on Funky. I updated it to the five-hour standard, and also switched the Security and IA requirements over (10h IA, 5h Security).

I also updated some of the commenting for consistency and removed the 40 overall time requirement because reaching the other time requirements requires more than 40 hours of playtime anyway.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

When considering the expectations of each department and how they relate to the Captain, IA feels way more relevant to Captain than Security. Also, while they should have knowledge of how Security functions, the Captain's role is much more relevant of the _procedure_ behind Space Law, which is better reflected by an IA requirement.

On top of that, consistency is good and the other timers being 4 hours was almost certainly an oversight.

## Technical details
<!-- Summary of code changes for easier review. -->

Did some shit with `Resources/Prototypes/Roles/Jobs/Command/captain.yml`. That's it really.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Make a new release build so prior dev playtime doesn't carry over.
2. Go to the customisation menu.
3. Look with your eyes :eyes:

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

<img width="1083" height="208" alt="Screenshot_20260823_072845" src="https://github.com/user-attachments/assets/c10ce7c1-e2c2-4f57-b3b0-6ab2cb5bd9e4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->

If you're not adding Internal Affairs or you don't like our style of role timers, revert this.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Captain's time requirements are now a consistent five hours on each department (except for IA, which is 10h, and Command, which is still 20h). Removed the 40 hour overall requirement as it is redundant.