### PR TITLE
Fix suicide test fail

### DIFF
--- a/Content.Server/Suicide/SuicideSystem.cs
+++ b/Content.Server/Suicide/SuicideSystem.cs
@@ -35,8 +35,10 @@ public sealed partial class SuicideSystem : SharedSuicideSystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<DamageableComponent, SuicideEvent>(OnDamageableSuicide);
-        SubscribeLocalEvent<MobStateComponent, SuicideEvent>(OnEnvironmentalSuicide);
+        // SubscribeLocalEvent<DamageableComponent, SuicideEvent>(OnDamageableSuicide);
+        // SubscribeLocalEvent<MobStateComponent, SuicideEvent>(OnEnvironmentalSuicide);
+        // Funky - we need to handle environmental suicide before default suicide
+        SubscribeLocalEvent<DamageableComponent, SuicideEvent>(OnEnvironmentalSuicide);
         SubscribeLocalEvent<MindContainerComponent, SuicideGhostEvent>(OnSuicideGhost);
     }
 
@@ -113,10 +115,15 @@ public sealed partial class SuicideSystem : SharedSuicideSystem
     /// <summary>
     /// Raise event to attempt to use held item, or surrounding entities to attempt to commit suicide
     /// </summary>
-    private void OnEnvironmentalSuicide(Entity<MobStateComponent> victim, ref SuicideEvent args)
+    private void OnEnvironmentalSuicide(Entity<DamageableComponent> victim, ref SuicideEvent args)
     {
-        if (args.Handled || _mobState.IsCritical(victim))
+        if (args.Handled)
             return;
+
+        // funky - use the default suicide method if we're in crit or there is no mob state component
+        // the goal being to make sure we try to environmental suicide before using default method
+        if (!HasComp<MobStateComponent>(victim) || _mobState.IsCritical(victim))
+            OnDamageableSuicide(victim, ref args);
 
         var suicideByEnvironmentEvent = new SuicideByEnvironmentEvent(victim);
 
@@ -146,6 +153,9 @@ public sealed partial class SuicideSystem : SharedSuicideSystem
             args.Handled = suicideByEnvironmentEvent.Handled;
             return;
         }
+
+        // funky - else, try to use the default suicide method
+        OnDamageableSuicide(victim, ref args);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
<!-- What did you change? -->
tiny refactor to suicide system to make sure it tries to use items and nearby objects BEFORE defaulting to tongue biting
### How to enable / disable
<!--
    According to our Conventions, all new content added should be easy for a downstream to disable or opt-out of.
    Content can be opt-out (or opt-in) through the use of CVars, simple YML changes, or simply by not using a feature (if it is made optional in some way, like a mapped entity or an admin-only commmand).

    Explain below how to enable or disable this content. If this is a bugfix, tweak, or a "non-content" change,
    this section can be omitted.
-->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
addresses https://github.com/funky-station/forky-station/issues/382
## Technical details
<!-- Summary of code changes for easier review. -->
only one function (OnEnvironmentalSuicide) is subscribed to SuicideEvent now
it checks if it should use the default suicide method before trying to use any of the other ones
if no other options are available then it uses the default method
therefore the default method is never run before it should be

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
possess urist -> type /suicide -> revive and repossess urist -> give urist melee weapon -> type /suicide -> revive and repossess urist -> self execute urist -> repeat for eternity for his torment shall never end
or just run SuicideCommandTests

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [ ] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->
OnEnvironmentalSuicide expects DamageableComponent instead of MobStateComponent now and calls OnDamageableSuicide itself instead of that being subscribed to an event
if this PR causes merge conflicts down the line i dont think anything would break if you completely overwrote it

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
