### PR TITLE
[Port] Sprinting from Starfall Drift

### DIFF
--- a/Content.Client/_Starfall/Particles/Visuals/FootstepDustSystem.cs
+++ b/Content.Client/_Starfall/Particles/Visuals/FootstepDustSystem.cs
@@ -1,0 +1,83 @@
+using System.Numerics;
+using Content.Shared._Starfall.Particles;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Movement.Components;
+using Robust.Client.Graphics;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Client._Starfall.Particles;
+
+/// <summary>
+/// Spawns dust particle puffs under entities' feet when they run.
+/// </summary>
+public sealed class FootstepDustSystem : EntitySystem
+{
+    [Dependency] private readonly ClientParticleSystem _particles = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IEyeManager _eye = default!;
+
+    private static readonly ProtoId<ParticleEffectPrototype> DustEffect = "SfFootstepDust";
+
+    // Tracks last spawn position for each entity to avoid spam
+    private readonly Dictionary<EntityUid, (MapCoordinates Pos, TimeSpan Time)> _lastDust = new();
+
+    private const float MinDistanceBetweenDust = 0.8f; // tiles
+    private const float MinTimeBetweenDust = 0.15f; // seconds
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var curTime = _timing.CurTime;
+        var toRemove = new List<EntityUid>();
+
+        var movers = EntityQueryEnumerator<InputMoverComponent, TransformComponent, MobStateComponent>();
+        while (movers.MoveNext(out var uid, out var mover, out var xform, out var mobState))
+        {
+            // Only spawn dust when sprinting (holding Walk key), actively moving, and alive
+            if (!mover.Sprinting || !mover.HasDirectionalMovement || mobState.CurrentState != Shared.Mobs.MobState.Alive)
+                continue;
+
+            var pos = _transform.GetMapCoordinates(uid, xform);
+
+            // The feet offset is screen-down (0, -0.75) — rotate it into world space
+            // so it always points toward the bottom of the screen regardless of grid rotation
+            var eyeRot = -(float)_eye.CurrentEye.Rotation;
+            var cosE = MathF.Cos(eyeRot);
+            var sinE = MathF.Sin(eyeRot);
+            const float feetOffset = -0.65f;
+            var worldFeetOffset = new Vector2(-feetOffset * sinE, feetOffset * cosE);
+            var feetPos = new MapCoordinates(pos.Position + worldFeetOffset, pos.MapId);
+
+            // Check if enough time AND distance has passed since last dust
+            if (_lastDust.TryGetValue(uid, out var last))
+            {
+                var timeSince = (curTime - last.Time).TotalSeconds;
+                var distSince = (feetPos.Position - last.Pos.Position).Length();
+
+                if (timeSince < MinTimeBetweenDust || distSince < MinDistanceBetweenDust)
+                    continue;
+            }
+
+            // Spawn dust at foot level
+            _particles.SpawnEffect(DustEffect, feetPos);
+            _lastDust[uid] = (feetPos, curTime);
+        }
+
+        // Cleanup old tracked entities
+        foreach (var (uid, _) in _lastDust)
+        {
+            if (!Exists(uid))
+                toRemove.Add(uid);
+        }
+
+        foreach (var uid in toRemove)
+        {
+            _lastDust.Remove(uid);
+        }
+    }
+}
+

--- a/Content.Client/_Starfall/Particles/Visuals/FootstepDustSystem.cs
+++ b/Content.Client/_Starfall/Particles/Visuals/FootstepDustSystem.cs
@@ -19,8 +19,6 @@ public sealed partial class FootstepDustSystem : EntitySystem
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private IEyeManager _eye = default!;
 
-    private static readonly ProtoId<ParticleEffectPrototype> DustEffect = "SfFootstepDust";
-
     // funky, a few loose pixels that scatter away from the feet alongside the dust puff
     private static readonly ProtoId<ParticleEffectPrototype> PixelDriftEffect = "SprintPixelDrift";
 
@@ -51,7 +49,7 @@ public sealed partial class FootstepDustSystem : EntitySystem
             var eyeRot = -(float)_eye.CurrentEye.Rotation;
             var cosE = MathF.Cos(eyeRot);
             var sinE = MathF.Sin(eyeRot);
-            const float feetOffset = -0.65f;
+            const float feetOffset = -0.55f;
             var worldFeetOffset = new Vector2(-feetOffset * sinE, feetOffset * cosE);
             var feetPos = new MapCoordinates(pos.Position + worldFeetOffset, pos.MapId);
 
@@ -65,10 +63,7 @@ public sealed partial class FootstepDustSystem : EntitySystem
                     continue;
             }
 
-            // Spawn dust at foot level
-            _particles.SpawnEffect(DustEffect, feetPos);
-
-            // funky, plus a couple stray pixels that drift off from the same spot
+            // funky, a couple stray pixels that drift off from the same spot
             _particles.SpawnEffect(PixelDriftEffect, feetPos);
 
             _lastDust[uid] = (feetPos, curTime);

--- a/Content.Client/_Starfall/Particles/Visuals/FootstepDustSystem.cs
+++ b/Content.Client/_Starfall/Particles/Visuals/FootstepDustSystem.cs
@@ -12,14 +12,17 @@ namespace Content.Client._Starfall.Particles;
 /// <summary>
 /// Spawns dust particle puffs under entities' feet when they run.
 /// </summary>
-public sealed class FootstepDustSystem : EntitySystem
+public sealed partial class FootstepDustSystem : EntitySystem
 {
-    [Dependency] private readonly ClientParticleSystem _particles = default!;
-    [Dependency] private readonly SharedTransformSystem _transform = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly IEyeManager _eye = default!;
+    [Dependency] private ParticleSystem _particles = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IEyeManager _eye = default!;
 
     private static readonly ProtoId<ParticleEffectPrototype> DustEffect = "SfFootstepDust";
+
+    // funky, a few loose pixels that scatter away from the feet alongside the dust puff
+    private static readonly ProtoId<ParticleEffectPrototype> PixelDriftEffect = "SprintPixelDrift";
 
     // Tracks last spawn position for each entity to avoid spam
     private readonly Dictionary<EntityUid, (MapCoordinates Pos, TimeSpan Time)> _lastDust = new();
@@ -64,6 +67,10 @@ public sealed class FootstepDustSystem : EntitySystem
 
             // Spawn dust at foot level
             _particles.SpawnEffect(DustEffect, feetPos);
+
+            // funky, plus a couple stray pixels that drift off from the same spot
+            _particles.SpawnEffect(PixelDriftEffect, feetPos);
+
             _lastDust[uid] = (feetPos, curTime);
         }
 
@@ -80,4 +87,3 @@ public sealed class FootstepDustSystem : EntitySystem
         }
     }
 }
-

--- a/Content.IntegrationTests/Tests/Movement/SlippingTest.cs
+++ b/Content.IntegrationTests/Tests/Movement/SlippingTest.cs
@@ -22,15 +22,16 @@ public sealed class SlippingTest : MovementTest
         // Player is to the left of the banana peel.
         Assert.That(Delta(), Is.GreaterThan(0.5f));
 
+        // funky, flipped these so that it holds walk to sprint, hacky as fuck LOL :yum:
         // Walking over the banana slowly does not trigger a slip.
-        await SetKey(EngineKeyFunctions.Walk, BoundKeyState.Down);
+        await SetKey(EngineKeyFunctions.Walk, BoundKeyState.Up); // funky
         await AssertFiresEvent<SlipEvent>(async () => await Move(DirectionFlag.East, 1f), count: 0);
 
         Assert.That(Delta(), Is.LessThan(0.5f));
         AssertComp<KnockedDownComponent>(false, Player);
 
         // Moving at normal speeds does trigger a slip.
-        await SetKey(EngineKeyFunctions.Walk, BoundKeyState.Up);
+        await SetKey(EngineKeyFunctions.Walk, BoundKeyState.Down); // funky
         await AssertFiresEvent<SlipEvent>(async () => await Move(DirectionFlag.West, 1f));
 
         // And the person that slipped was the player
@@ -38,4 +39,3 @@ public sealed class SlippingTest : MovementTest
         AssertComp<KnockedDownComponent>(true, Player);
     }
 }
-

--- a/Content.Server/_Starfall/Systems/SprintStaminaSystem.cs
+++ b/Content.Server/_Starfall/Systems/SprintStaminaSystem.cs
@@ -1,0 +1,27 @@
+using Content.Shared.Damage.Systems;
+using Content.Shared.Movement.Components;
+using Content.Shared.Damage.Components;
+
+namespace Content.Server._Starfall.Systems;
+
+public sealed class SprintStaminaSystem : EntitySystem
+{
+    [Dependency] private readonly SharedStaminaSystem _stamina = default!;
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var enumerator = EntityQueryEnumerator<InputMoverComponent, StaminaComponent>();
+
+        while (enumerator.MoveNext(out var uid, out var mover, out var stam))
+        {
+            if (!mover.HasDirectionalMovement || !mover.Sprinting)
+                continue;
+
+            // _Stardrift: Drain stamina while sprinting using upstream config.
+            var drain = stam.SprintDrainPerSecond * frameTime;
+            _stamina.TakeStaminaDamage(uid, drain, component: stam, visual: false);
+        }
+    }
+}

--- a/Content.Server/_Starfall/Systems/SprintStaminaSystem.cs
+++ b/Content.Server/_Starfall/Systems/SprintStaminaSystem.cs
@@ -4,9 +4,9 @@ using Content.Shared.Damage.Components;
 
 namespace Content.Server._Starfall.Systems;
 
-public sealed class SprintStaminaSystem : EntitySystem
+public sealed partial class SprintStaminaSystem : EntitySystem
 {
-    [Dependency] private readonly SharedStaminaSystem _stamina = default!;
+    [Dependency] private SharedStaminaSystem _stamina = default!;
 
     public override void Update(float frameTime)
     {

--- a/Content.Shared/Damage/Components/StaminaComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaComponent.cs
@@ -98,7 +98,7 @@ public sealed partial class StaminaComponent : Component
 
     // _Stardrift: How much stamina is drained per second while sprinting (default).
     [DataField, AutoNetworkedField]
-    public float SprintDrainPerSecond = 2.5f;
+    public float SprintDrainPerSecond = 3.33f;
 
     #region Animation Data
 

--- a/Content.Shared/Damage/Components/StaminaComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaComponent.cs
@@ -96,6 +96,10 @@ public sealed partial class StaminaComponent : Component
     [DataField]
     public Dictionary<FixedPoint2, float> StunModifierThresholds = new() { {0, 1f }, { 0.6, 0.7f }, { 0.8, 0.5f } };
 
+    // _Stardrift: How much stamina is drained per second while sprinting (default).
+    [DataField, AutoNetworkedField]
+    public float SprintDrainPerSecond = 2.5f;
+
     #region Animation Data
 
     /// <summary>

--- a/Content.Shared/Movement/Components/InputMoverComponent.cs
+++ b/Content.Shared/Movement/Components/InputMoverComponent.cs
@@ -82,8 +82,9 @@ namespace Content.Shared.Movement.Components
         public const float SprintingSoundModifier = 3.5f;
         public const float WalkingSoundModifier = 1.5f;
 
-        [ViewVariables]
-        public bool Sprinting => (HeldMoveButtons & MoveButtons.Walk) == 0x0;
+        // _Stardrift: Sprinting is active when the Walk bit is held. This makes the default state "walking"
+        // _Stardrift: and holding the Walk key (Shift by default) enable running/sprinting.
+        public bool Sprinting => (HeldMoveButtons & MoveButtons.Walk) != 0x0;
 
         [ViewVariables(VVAccess.ReadWrite)]
         public bool CanMove = true;

--- a/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
+++ b/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
@@ -25,8 +25,8 @@ namespace Content.Shared.Movement.Components
         public const float DefaultMinimumFrictionSpeed = 0.005f;
 
         // movement
-        public const float DefaultBaseWalkSpeed = 2.5f;
-        public const float DefaultBaseSprintSpeed = 4.5f;
+        public const float DefaultBaseWalkSpeed = 2.75f; // funky
+        public const float DefaultBaseSprintSpeed = 4.95f; // funky
 
         // ES START
         public static Angle ESDefaultBackwardsAngle = Angle.FromDegrees(150);

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -373,9 +373,9 @@ public abstract partial class SharedMoverController : VirtualController
             }
 
             // ES START
-            // no footsteps on walk
+            // funky: footsteps now play on walk too, quieter
             if (!weightless && MobMoverQuery.TryGetComponent(uid, out var mobMover) &&
-                mover.Sprinting && !forceWalk &&
+                !forceWalk &&
                 TryGetSound(weightless, uid, mover, mobMover, xform, out var sound, tileDef: tileDef))
             {
                 // ES END

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -144,13 +144,13 @@ ui-options-header-text-chat = Chat
 ui-options-header-text-other = Text input other
 
 ui-options-hotkey-keymap = Use US QWERTY Keys
-ui-options-hotkey-toggle-walk = Toggle Walk
+ui-options-hotkey-toggle-walk = Toggle Sprint
 
 ui-options-function-move-up = Move Up
 ui-options-function-move-left = Move Left
 ui-options-function-move-down = Move Down
 ui-options-function-move-right = Move Right
-ui-options-function-walk = Walk
+ui-options-function-walk = Sprint
 ui-options-function-toggle-knockdown = Toggle Crawling
 
 ui-options-function-camera-rotate-left = Rotate left

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -144,12 +144,14 @@ ui-options-header-text-chat = Chat
 ui-options-header-text-other = Text input other
 
 ui-options-hotkey-keymap = Use US QWERTY Keys
+# funky, changed walk to sprint
 ui-options-hotkey-toggle-walk = Toggle Sprint
 
 ui-options-function-move-up = Move Up
 ui-options-function-move-left = Move Left
 ui-options-function-move-down = Move Down
 ui-options-function-move-right = Move Right
+# funky, changed walk to sprint
 ui-options-function-walk = Sprint
 ui-options-function-toggle-knockdown = Toggle Crawling
 

--- a/Resources/Prototypes/_Funkystation/Entities/Effects/footprint_dust.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Effects/footprint_dust.yml
@@ -9,7 +9,7 @@
   lifetimeVariance: 0.2
   speed: 1.2
   speedVariance: 0.6
-  particleSize: 0.2
+  particleSize: 0.7
   sizeVariance: 0.05
   emissionRate: 0
   maxCount: 3

--- a/Resources/Prototypes/_Funkystation/Entities/Effects/footprint_dust.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Effects/footprint_dust.yml
@@ -1,0 +1,25 @@
+﻿- type: particleEffect
+  id: SprintPixelDrift
+  sprite:
+    sprite: _Starfall/Particles/generic.rsi
+    state: dot
+  startColor: "#FFFFFFFF"
+  endColor: "#FFFFFF00"
+  lifetime: 0.5
+  lifetimeVariance: 0.2
+  speed: 1.2
+  speedVariance: 0.6
+  particleSize: 0.2
+  sizeVariance: 0.05
+  emissionRate: 0
+  maxCount: 3
+  burst: true
+  gravity: -0.05
+  drag: 0.3
+  noiseStrength: 0.1
+  noiseFrequency: 0.5
+  spreadAngle: 360
+  emitAngle: 0
+  shape:
+    type: CircleFill
+    radius: 0.05

--- a/Resources/Prototypes/_Starfall/particle_effects.yml
+++ b/Resources/Prototypes/_Starfall/particle_effects.yml
@@ -253,7 +253,7 @@
   sprite:
     sprite: Effects/chemsmoke.rsi
     state: chemsmoke
-  startColor: "#CCCCCC88"
+  startColor: "#CCCCCC55" # funky, slightly more transparent
   endColor: "#CCCCCC00"
   sizeOverLifetime:
     - time: 0.0


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
This PR is a cherry-pick of [this PR from Starfall Drift](https://github.com/Starfall-Drift/Starfall-Drift/pull/2) by [TrixxedHeart](https://github.com/TrixxedHeart).
It changes the default movement speed to walking, and instead makes holding shift allow you to sprint, with particle effects for emphasis, which slowly drains your stamina. You can sprint for about 30 seconds straight before going stam-crit.

I have increased the default movement speeds by 10%, which makes walking a little less tedious.
<!-- What did you change? -->

### How to enable / disable
Revert this PR.
<!--
    According to our Conventions, all new content added should be easy for a downstream to disable or opt-out of.
    Content can be opt-out (or opt-in) through the use of CVars, simple YML changes, or simply by not using a feature (if it is made optional in some way, like a mapped entity or an admin-only commmand).

    Explain below how to enable or disable this content. If this is a bugfix, tweak, or a "non-content" change,
    this section can be omitted.
-->

## Why / Balance
This is something we wanted for Forky, and Starfall Drift's implementation of it is elegant and functional. It makes things feel more grounded, in general.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
See original PR.
I've swapped the particles spawned from the original dust clouds to a few stray drifting pixels, which I think fits our aesthetic more.
<!-- Summary of code changes for easier review. -->

## Test plan
Spawn in. Sprint around!
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
https://github.com/user-attachments/assets/f344ab08-e3e3-4076-814c-6b9f5ccb9d26

<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->

## Changelog
:cl: TrixxedHeart, AraiMaia
- add: Added sprinting.
- tweak: Default movement is now walking.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
