### PR TITLE
Fix - crew monitoring search refresh

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -41,6 +41,9 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
         _spriteSystem = _entManager.System<SpriteSystem>();
 
         NavMap.TrackedEntitySelectedAction += SetTrackedEntityFromNavMap;
+
+        // Funky, rebuild the crew list when the search text changes
+        SearchLineEdit.OnTextChanged += OnSearchLineTextChanged;
     }
 
     public void Set(string stationName, EntityUid? mapUid)
@@ -79,88 +82,9 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
 
         NoServerLabel.Visible = false;
 
-        // Collect one status per user, using the sensor with the most data available.
-        Dictionary<NetEntity, SuitSensorStatus> uniqueSensorsMap = new();
-        foreach (var sensor in sensors)
-        {
-            if (uniqueSensorsMap.TryGetValue(sensor.OwnerUid, out var existingSensor))
-            {
-                // Skip if we already have a sensor with more data for this mob.
-                if (existingSensor.Coordinates != null && sensor.Coordinates == null)
-                    continue;
-
-                if (existingSensor.DamagePercentage != null && sensor.DamagePercentage == null)
-                    continue;
-            }
-
-            uniqueSensorsMap[sensor.OwnerUid] = sensor;
-        }
-        var uniqueSensors = uniqueSensorsMap.Values.ToList();
-
-        // Order sensor data
-        var orderedSensors = uniqueSensors.OrderBy(n => n.Name).OrderBy(j => j.Job);
-        var assignedSensors = new HashSet<SuitSensorStatus>();
-        var departments = uniqueSensors.SelectMany(d => d.JobDepartments).Distinct().OrderBy(n => n);
-
-        // Create department labels and populate lists
-        foreach (var department in departments)
-        {
-            var departmentSensors = orderedSensors.Where(d => d.JobDepartments.Contains(department));
-
-            if (departmentSensors == null || !departmentSensors.Any())
-                continue;
-
-            foreach (var sensor in departmentSensors)
-                assignedSensors.Add(sensor);
-
-            if (SensorsTable.ChildCount > 0)
-            {
-                var spacer = new Control()
-                {
-                    SetHeight = 20,
-                };
-
-                SensorsTable.AddChild(spacer);
-            }
-
-            var deparmentLabel = new RichTextLabel()
-            {
-                Margin = new Thickness(10, 0),
-                HorizontalExpand = true,
-            };
-
-            deparmentLabel.SetMessage(department);
-            deparmentLabel.StyleClasses.Add("font-large");
-
-            SensorsTable.AddChild(deparmentLabel);
-
-            PopulateDepartmentList(departmentSensors);
-        }
-
-        // Account for any non-station users
-        var remainingSensors = orderedSensors.Except(assignedSensors);
-
-        if (remainingSensors.Any())
-        {
-            var spacer = new Control()
-            {
-                SetHeight = 20,
-            };
-
-            SensorsTable.AddChild(spacer);
-
-            var deparmentLabel = new RichTextLabel()
-            {
-                Margin = new Thickness(10, 0),
-                HorizontalExpand = true,
-            };
-
-            deparmentLabel.SetMessage(Loc.GetString("crew-monitoring-ui-no-department-label"));
-
-            SensorsTable.AddChild(deparmentLabel);
-
-            PopulateDepartmentList(remainingSensors);
-        }
+        // Funky, Cache unique sensor data so the crew list can be rebuilt locally
+        _uniqueSensors = GetUniqueSensorsList(sensors);
+        RebuildSensorsTable();
 
         // Show monitor on nav map
         if (monitorCoords != null && _blipTexture != null)

--- a/Content.Client/_Funkystation/Medical/CrewMonitoring/CrewMonitoringWindow.cs
+++ b/Content.Client/_Funkystation/Medical/CrewMonitoring/CrewMonitoringWindow.cs
@@ -9,6 +9,7 @@ public sealed partial class CrewMonitoringWindow
 {
     private List<SuitSensorStatus> _uniqueSensors = [];
 
+    // Gets called each time the search bar changes
     private void OnSearchLineTextChanged(LineEdit.LineEditEventArgs args)
     {
         RebuildSensorsTable();
@@ -34,37 +35,22 @@ public sealed partial class CrewMonitoringWindow
                 .Where(sensor => sensor.JobDepartments.Contains(department))
                 .ToList();
 
-            // Checks if the department has at least one sensor matching the search filter
-            // if not, don't add the department label
-            if (departmentSensors.Count == 0 || !departmentSensors.Any(MatchesSearchFilter))
-                continue;
-
-            if (SensorsTable.ChildCount > 0)
-            {
-                SensorsTable.AddChild(new Control
-                {
-                    SetHeight = 20,
-                });
-            }
-
-            var departmentLabel = new RichTextLabel
-            {
-                Margin = new Thickness(10, 0),
-                HorizontalExpand = true,
-            };
-
-            departmentLabel.SetMessage(department);
-            departmentLabel.StyleClasses.Add("font-large");
-
-            SensorsTable.AddChild(departmentLabel);
-            PopulateDepartmentList(departmentSensors);
+            AddDepartmentToSensorsTable(department, departmentSensors);
         }
 
         var remainingSensors = orderedSensors
             .Where(sensor => sensor.JobDepartments.Count == 0)
             .ToList();
 
-        if (remainingSensors.Count == 0 || !remainingSensors.Any(MatchesSearchFilter))
+        AddDepartmentToSensorsTable(Loc.GetString("crew-monitoring-ui-no-department-label"), remainingSensors);
+    }
+
+    // Appends the department and its sensors to the sensors table
+    private void AddDepartmentToSensorsTable(string departmentName, List<SuitSensorStatus> departmentSensors)
+    {
+
+        // Checks if at least one sensor inside the department matches the filter on the search bar
+        if (departmentSensors.Count == 0 || !departmentSensors.Any(MatchesSearchFilter))
             return;
 
         if (SensorsTable.ChildCount > 0)
@@ -75,17 +61,17 @@ public sealed partial class CrewMonitoringWindow
             });
         }
 
-        var noDepartmentLabel = new RichTextLabel
+        var departmentLabel = new RichTextLabel
         {
             Margin = new Thickness(10, 0),
             HorizontalExpand = true,
         };
 
-        noDepartmentLabel.SetMessage(Loc.GetString("crew-monitoring-ui-no-department-label"));
-        noDepartmentLabel.StyleClasses.Add("font-large");
+        departmentLabel.SetMessage(departmentName);
+        departmentLabel.StyleClasses.Add("font-large");
 
-        SensorsTable.AddChild(noDepartmentLabel);
-        PopulateDepartmentList(remainingSensors);
+        SensorsTable.AddChild(departmentLabel);
+        PopulateDepartmentList(departmentSensors);
     }
 
     private static List<SuitSensorStatus> GetUniqueSensorsList(List<SuitSensorStatus> allSensors)
@@ -95,7 +81,7 @@ public sealed partial class CrewMonitoringWindow
         {
             if (uniqueSensorsMap.TryGetValue(sensor.OwnerUid, out var existingSensor))
             {
-                // Skip if we already have a sensor with more data for this mob.
+                // Skip if we already have a sensor with more data for this entity
                 if (existingSensor.Coordinates != null && sensor.Coordinates == null)
                     continue;
 
@@ -109,6 +95,8 @@ public sealed partial class CrewMonitoringWindow
         return uniqueSensorsMap.Values.ToList();
     }
 
+    // Search filter for the search bar
+    // Matches the filtering logic used upstream, extracted in its own method
     private bool MatchesSearchFilter(SuitSensorStatus sensor)
     {
         return string.IsNullOrEmpty(SearchLineEdit.Text)

--- a/Content.Client/_Funkystation/Medical/CrewMonitoring/CrewMonitoringWindow.cs
+++ b/Content.Client/_Funkystation/Medical/CrewMonitoring/CrewMonitoringWindow.cs
@@ -1,0 +1,122 @@
+﻿using System.Linq;
+using Content.Shared.Medical.SuitSensor;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+
+namespace Content.Client.Medical.CrewMonitoring;
+
+public sealed partial class CrewMonitoringWindow
+{
+    private List<SuitSensorStatus> _uniqueSensors = [];
+
+    private void OnSearchLineTextChanged(LineEdit.LineEditEventArgs args)
+    {
+        RebuildSensorsTable();
+    }
+
+    private void RebuildSensorsTable()
+    {
+        ClearOutDatedData();
+
+        var orderedSensors = _uniqueSensors
+            .OrderBy(n => n.Name)
+            .ThenBy(j => j.Job)
+            .ToList();
+
+        var departments = _uniqueSensors
+            .SelectMany(sensor => sensor.JobDepartments)
+            .Distinct()
+            .OrderBy(department => department);
+
+        foreach (var department in departments)
+        {
+            var departmentSensors = orderedSensors
+                .Where(sensor => sensor.JobDepartments.Contains(department))
+                .ToList();
+
+            // Checks if the department has at least one sensor matching the search filter
+            // if not, don't add the department label
+            if (departmentSensors.Count == 0 || !departmentSensors.Any(MatchesSearchFilter))
+                continue;
+
+            if (SensorsTable.ChildCount > 0)
+            {
+                SensorsTable.AddChild(new Control
+                {
+                    SetHeight = 20,
+                });
+            }
+
+            var departmentLabel = new RichTextLabel
+            {
+                Margin = new Thickness(10, 0),
+                HorizontalExpand = true,
+            };
+
+            departmentLabel.SetMessage(department);
+            departmentLabel.StyleClasses.Add("font-large");
+
+            SensorsTable.AddChild(departmentLabel);
+            PopulateDepartmentList(departmentSensors);
+        }
+
+        var remainingSensors = orderedSensors
+            .Where(sensor => sensor.JobDepartments.Count == 0)
+            .ToList();
+
+        if (remainingSensors.Count == 0 || !remainingSensors.Any(MatchesSearchFilter))
+            return;
+
+        if (SensorsTable.ChildCount > 0)
+        {
+            SensorsTable.AddChild(new Control
+            {
+                SetHeight = 20,
+            });
+        }
+
+        var noDepartmentLabel = new RichTextLabel
+        {
+            Margin = new Thickness(10, 0),
+            HorizontalExpand = true,
+        };
+
+        noDepartmentLabel.SetMessage(Loc.GetString("crew-monitoring-ui-no-department-label"));
+        noDepartmentLabel.StyleClasses.Add("font-large");
+
+        SensorsTable.AddChild(noDepartmentLabel);
+        PopulateDepartmentList(remainingSensors);
+    }
+
+    private static List<SuitSensorStatus> GetUniqueSensorsList(List<SuitSensorStatus> allSensors)
+    {
+        Dictionary<NetEntity, SuitSensorStatus> uniqueSensorsMap = new();
+        foreach (var sensor in allSensors)
+        {
+            if (uniqueSensorsMap.TryGetValue(sensor.OwnerUid, out var existingSensor))
+            {
+                // Skip if we already have a sensor with more data for this mob.
+                if (existingSensor.Coordinates != null && sensor.Coordinates == null)
+                    continue;
+
+                if (existingSensor.DamagePercentage != null && sensor.DamagePercentage == null)
+                    continue;
+            }
+
+            uniqueSensorsMap[sensor.OwnerUid] = sensor;
+        }
+
+        return uniqueSensorsMap.Values.ToList();
+    }
+
+    private bool MatchesSearchFilter(SuitSensorStatus sensor)
+    {
+        return string.IsNullOrEmpty(SearchLineEdit.Text)
+               || sensor.Name.Contains(
+                   SearchLineEdit.Text,
+                   StringComparison.CurrentCultureIgnoreCase)
+               || sensor.Job.Contains(
+                   SearchLineEdit.Text,
+                   StringComparison.CurrentCultureIgnoreCase);
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
<!-- What did you change? -->
The crew monitoring console search field now updates the sensor list immediately when its text changes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix. 

The crew monitoring console receives sensor updates from the server roughly once per second. Previously, the search filter was only applied when of these updates was received.

The search field now refreshes the displayed crew members immediately as the player types.

## Technical details
<!-- Summary of code changes for easier review. -->
- Cached the latest unique sensors inside a private `_uniqueSensors` field.
- Added the changes in a partial class under `Content.Client\_Funkystation\Medical\CrewMonitoring\CrewMonitoringWindow.cs` to minimize modifications to upstream code.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
- Tested the crew monitor console window by spawning some random roles.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

Before:

https://github.com/user-attachments/assets/53e0d1e0-2592-43a7-86fb-98f4ad5cd3e1

After:

https://github.com/user-attachments/assets/5dc44f26-8dce-49f5-b32d-b9add2e66397

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->
None.

## Changelog
:cl: WiZ88
- fix: Crew Monitoring console search bar now refreshes instantly
