### PR TITLE
[PORT] RMC14 Chat Stacking from Persistence

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -771,7 +771,7 @@ public sealed partial class ChatUIController : UIController
         {
             var locWarning = Loc.GetString("chat-manager-max-message-length",
                 ("maxMessageLength", MaxMessageLength));
-            box.AddLine(locWarning, Color.Orange);
+            box.AddLine(locWarning, Color.Orange, default, locWarning, ChatChannel.Server, true); // Persistence: Chat stacking from RMC14 - pull/7587
             return;
         }
 

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -1,3 +1,4 @@
+using Content.Client._RMC14.Chat; // Persistence: Chat stacking from RMC14 - pull/7587
 using Content.Client.UserInterface.Systems.Chat.Controls;
 using Content.Shared.Chat;
 using Content.Shared.Input;
@@ -28,6 +29,8 @@ public partial class ChatBox : UIWidget
     public bool Main { get; set; }
 
     public ChatSelectChannel SelectedChannel => ChatInput.ChannelSelector.SelectedChannel;
+
+    public readonly Queue<RepeatedMessage> RepeatQueue = new(); // Persistence: Chat stacking from RMC14 - pull/7587
 
     public ChatBox()
     {
@@ -68,7 +71,7 @@ public partial class ChatBox : UIWidget
 
         var color = msg.MessageColorOverride ?? msg.Channel.TextColor();
 
-        AddLine(msg.WrappedMessage, color);
+        AddLine(msg.WrappedMessage, color, msg.SenderEntity, msg.Message, msg.Channel, msg.RepeatCheckSender); // Persistence: Chat stacking from RMC14 - pull/7587
     }
 
     private void OnHighlightsUpdated(string highlights)
@@ -111,12 +114,17 @@ public partial class ChatBox : UIWidget
         _controller.UpdateHighlights(highlighs);
     }
 
-    public void AddLine(string message, Color color)
+    public void AddLine(string message, Color color, NetEntity sender, string unwrapped, ChatChannel channel, bool repeatCheckSender) // Persistence: Chat stacking from RMC14 - pull/7587
     {
         var formatted = new FormattedMessage(3);
         formatted.PushColor(color);
         formatted.AddMarkupOrThrow(message);
         formatted.Pop();
+
+        // Persistence: Chat stacking from RMC14 - pull/7587
+        if (_entManager.System<CMChatSystem>().TryRepetition(this, Contents, formatted, sender, unwrapped, channel, repeatCheckSender))
+            return;
+
         Contents.AddMessage(formatted, tagsAllowed: null);
     }
 

--- a/Content.Client/_RMC14/Chat/CMChatSystem.cs
+++ b/Content.Client/_RMC14/Chat/CMChatSystem.cs
@@ -1,0 +1,64 @@
+﻿// Persistence: Chat stacking from RMC14 - pull/7587
+using Content.Client.UserInterface.Systems.Chat.Widgets;
+using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Chat;
+using Content.Shared.Chat;
+using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Configuration;
+using Robust.Shared.Utility;
+
+namespace Content.Client._RMC14.Chat;
+
+public sealed class CMChatSystem : EntitySystem // Persistence: SharedCMChatSystem < EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _config = default!;
+
+    private int _repeatHistory;
+
+    public override void Initialize()
+    {
+        // base.Initialize();
+
+        Subs.CVar(_config, RMCCVars.RMCChatRepeatHistory, v => _repeatHistory = v, true);
+    }
+
+    public bool TryRepetition(ChatBox chat, OutputPanel contents, FormattedMessage message, NetEntity sender, string unwrapped, ChatChannel channel, bool repeatCheckSender)
+    {
+        var repeated = false;
+        foreach (var old in chat.RepeatQueue)
+        {
+            if (!old.Message.Equals(unwrapped) ||
+                old.Channel != channel)
+            {
+                continue;
+            }
+
+            if (repeatCheckSender &&
+                !old.SenderEntity.Equals(sender))
+            {
+                continue;
+            }
+
+            var copy = new FormattedMessage(old.FormattedMessage);
+            old.Count++;
+            copy.AddMarkupPermissive($" [color=red]x{old.Count}[/color]");
+            contents.SetMessage(old.Index, copy);
+            repeated = true;
+            break;
+        }
+
+        if (!repeated)
+        {
+            chat.RepeatQueue.Enqueue(new RepeatedMessage(contents.EntryCount, message, sender, unwrapped, channel));
+            if (_repeatHistory > 0)
+            {
+                while (chat.RepeatQueue.Count > _repeatHistory)
+                {
+                    chat.RepeatQueue.Dequeue();
+                }
+            }
+        }
+
+        return repeated;
+    }
+}

--- a/Content.Client/_RMC14/Chat/CMChatSystem.cs
+++ b/Content.Client/_RMC14/Chat/CMChatSystem.cs
@@ -1,7 +1,6 @@
 ﻿// Persistence: Chat stacking from RMC14 - pull/7587
 using Content.Client.UserInterface.Systems.Chat.Widgets;
 using Content.Shared._RMC14.CCVar;
-using Content.Shared._RMC14.Chat;
 using Content.Shared.Chat;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Configuration;
@@ -9,9 +8,9 @@ using Robust.Shared.Utility;
 
 namespace Content.Client._RMC14.Chat;
 
-public sealed class CMChatSystem : EntitySystem // Persistence: SharedCMChatSystem < EntitySystem
+public sealed partial class CMChatSystem : EntitySystem // Persistence: SharedCMChatSystem < EntitySystem
 {
-    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private IConfigurationManager _config = default!;
 
     private int _repeatHistory;
 

--- a/Content.Client/_RMC14/Chat/CMChatSystem.cs
+++ b/Content.Client/_RMC14/Chat/CMChatSystem.cs
@@ -23,6 +23,9 @@ public sealed partial class CMChatSystem : EntitySystem // Persistence: SharedCM
 
     public bool TryRepetition(ChatBox chat, OutputPanel contents, FormattedMessage message, NetEntity sender, string unwrapped, ChatChannel channel, bool repeatCheckSender)
     {
+        if (ChatChannel.AdminRelated.HasFlag(channel)) // Persistence: don't stack anything that's admin-chat related
+            return false;
+
         var repeated = false;
         foreach (var old in chat.RepeatQueue)
         {

--- a/Content.Client/_RMC14/Chat/CMChatSystem.cs
+++ b/Content.Client/_RMC14/Chat/CMChatSystem.cs
@@ -44,7 +44,7 @@ public sealed partial class CMChatSystem : EntitySystem // Persistence: SharedCM
             var copy = new FormattedMessage(old.FormattedMessage);
             old.Count++;
             copy.AddMarkupPermissive($" [color=red]x{old.Count}[/color]");
-            contents.SetMessage(old.Index, copy);
+            contents.SetMessage(old.Index, copy, tagsAllowed: null);
             repeated = true;
             break;
         }

--- a/Content.Client/_RMC14/Chat/RepeatedMessage.cs
+++ b/Content.Client/_RMC14/Chat/RepeatedMessage.cs
@@ -1,0 +1,21 @@
+﻿// Persistence: Chat stacking from RMC14 - pull/7587
+using Content.Shared.Chat;
+using Robust.Shared.Utility;
+
+namespace Content.Client._RMC14.Chat;
+
+public sealed class RepeatedMessage(
+    int index,
+    FormattedMessage formattedMessage,
+    NetEntity senderEntity,
+    string message,
+    ChatChannel channel
+)
+{
+    public readonly int Index = index;
+    public readonly FormattedMessage FormattedMessage = formattedMessage;
+    public readonly NetEntity SenderEntity = senderEntity;
+    public readonly string Message = message;
+    public readonly ChatChannel Channel = channel;
+    public int Count = 1;
+}

--- a/Content.Server/Chat/Managers/ChatManager.cs
+++ b/Content.Server/Chat/Managers/ChatManager.cs
@@ -9,7 +9,7 @@ using Content.Server.Discord.DiscordLink;
 using Content.Server.Ghost;
 using Content.Server.Players.RateLimiting;
 using Content.Server.Preferences.Managers;
-using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.CCVar; // RMC Mentor Chat Funky Port
 using Content.Shared._RMC14.Chat; // Persistence: Chat stacking from RMC14 - pull/7587
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
@@ -459,9 +459,8 @@ internal sealed partial class ChatManager : IChatManager
         {
             var customWrapMessage = PrependFollowButtonIfAppropriate(wrappedMessage, source, client);
             var msg = new ChatMessage(channel, message, wrappedMessage, netSource, user?.Key, hideChat, colorOverride, audioPath, audioVolume, repeatCheckSender: !_entityManager.HasComponent<ChatRepeatIgnoreSenderComponent>(source)); // Persistence: Chat stacking from RMC14 - pull/7587
-            _netManager.ServerSendToMany(new MsgChatMessage() { Message = msg }, clients);
+            _netManager.ServerSendToMany(new MsgChatMessage() { Message = msg }, clients); // Persistence: Chat stacking from RMC14 - pull/7587
         }
-
 
         if (!recordReplay)
             return;

--- a/Content.Server/Chat/Managers/ChatManager.cs
+++ b/Content.Server/Chat/Managers/ChatManager.cs
@@ -9,7 +9,8 @@ using Content.Server.Discord.DiscordLink;
 using Content.Server.Ghost;
 using Content.Server.Players.RateLimiting;
 using Content.Server.Preferences.Managers;
-using Content.Shared._RMC14.CCVar; // RMC Mentor Chat Funky Port
+using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Chat; // Persistence: Chat stacking from RMC14 - pull/7587
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
 using Content.Shared.Chat;
@@ -432,7 +433,7 @@ internal sealed partial class ChatManager : IChatManager
         user?.AddEntity(netSource);
 
         wrappedMessage = PrependFollowButtonIfAppropriate(wrappedMessage, source, client);
-        var msg = new ChatMessage(channel, message, wrappedMessage, netSource, user?.Key, hideChat, colorOverride, audioPath, audioVolume);
+        var msg = new ChatMessage(channel, message, wrappedMessage, netSource, user?.Key, hideChat, colorOverride, audioPath, audioVolume, repeatCheckSender: !_entityManager.HasComponent<ChatRepeatIgnoreSenderComponent>(source)); // Persistence: Chat stacking from RMC14 - pull/7587
         _netManager.ServerSendMessage(new MsgChatMessage() { Message = msg }, client);
 
         if (!recordReplay)
@@ -457,9 +458,10 @@ internal sealed partial class ChatManager : IChatManager
         foreach (var client in clients)
         {
             var customWrapMessage = PrependFollowButtonIfAppropriate(wrappedMessage, source, client);
-            var msg = new ChatMessage(channel, message, customWrapMessage, netSource, user?.Key, hideChat, colorOverride, audioPath, audioVolume);
-            _netManager.ServerSendMessage(new MsgChatMessage { Message = msg }, client);
+            var msg = new ChatMessage(channel, message, wrappedMessage, netSource, user?.Key, hideChat, colorOverride, audioPath, audioVolume, repeatCheckSender: !_entityManager.HasComponent<ChatRepeatIgnoreSenderComponent>(source)); // Persistence: Chat stacking from RMC14 - pull/7587
+            _netManager.ServerSendToMany(new MsgChatMessage() { Message = msg }, clients);
         }
+
 
         if (!recordReplay)
             return;
@@ -493,7 +495,7 @@ internal sealed partial class ChatManager : IChatManager
         var netSource = _entityManager.GetNetEntity(source);
         user?.AddEntity(netSource);
 
-        var msg = new ChatMessage(channel, message, wrappedMessage, netSource, user?.Key, hideChat, colorOverride, audioPath, audioVolume);
+        var msg = new ChatMessage(channel, message, wrappedMessage, netSource, user?.Key, hideChat, colorOverride, audioPath, audioVolume, repeatCheckSender: !_entityManager.HasComponent<ChatRepeatIgnoreSenderComponent>(source)); // Persistence: Chat stacking from RMC14 - pull/7587
         _netManager.ServerSendToAll(new MsgChatMessage() { Message = msg });
 
         if (!recordReplay)

--- a/Content.Server/Chat/Systems/ChatSystem.PrivateAPI.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.PrivateAPI.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared._RMC14.Chat; // Persistence: Chat stacking from RMC14 - pull/7587
 using Content.Shared.Chat;
 using Content.Shared.Database;
 using Content.Shared.IdentityManagement;
@@ -160,7 +161,7 @@ public sealed partial class ChatSystem
                 _chatManager.ChatMessageToOne(ChatChannel.Whisper, obfuscatedMessage, wrappedUnknownMessage, source, false, session.Channel);
         }
 
-        _replay.RecordServerMessage(new ChatMessage(ChatChannel.Whisper, message, wrappedMessage, GetNetEntity(source), null, MessageRangeHideChatForReplay(range)));
+        _replay.RecordServerMessage(new ChatMessage(ChatChannel.Whisper, message, wrappedMessage, GetNetEntity(source), null, MessageRangeHideChatForReplay(range), repeatCheckSender: !HasComp<ChatRepeatIgnoreSenderComponent>(source))); // Persistence: Chat stacking from RMC14 - pull/7587
 
         var ev = new EntitySpokeEvent(source, message, channel, obfuscatedMessage);
         RaiseLocalEvent(source, ev, true);

--- a/Content.Server/Chat/Systems/ChatSystem.Utility.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.Utility.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Text;
+using Content.Shared._RMC14.Chat; // Persistence: Chat stacking from RMC14 - pull/7587
 using Content.Shared.Chat;
 using Content.Shared.Ghost.Components;
 using Content.Shared.Players;
@@ -75,7 +76,7 @@ public sealed partial class ChatSystem
             _chatManager.ChatMessageToOne(channel, message, wrappedMessage, source, entHideChat, session.Channel, author: author);
         }
 
-        _replay.RecordServerMessage(new ChatMessage(channel, message, wrappedMessage, GetNetEntity(source), null, MessageRangeHideChatForReplay(range)));
+        _replay.RecordServerMessage(new ChatMessage(channel, message, wrappedMessage, GetNetEntity(source), null, MessageRangeHideChatForReplay(range), repeatCheckSender: !HasComp<ChatRepeatIgnoreSenderComponent>(source))); // Persistence: Chat stacking from RMC14 - pull/7587_replay.RecordServerMessage(new ChatMessage(channel, message, wrappedMessage, GetNetEntity(source), null, MessageRangeHideChatForReplay(range)));
     }
 
     /// <summary>

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -110,7 +110,7 @@ public sealed partial class RadioSystem : SharedRadioSystem
             ChatChannel.Radio,
             message,
             wrappedMessage,
-            NetEntity.Invalid,
+            GetNetEntity(messageSource), // Persistence: Chat stacking from RMC14 - pull/7587
             _chatManager.EnsurePlayer(CompOrNull<ActorComponent>(messageSource)?.PlayerSession.UserId)?.Key,  // Persistence: Chat stacking from RMC14 - pull/7587
             repeatCheckSender: !HasComp<ChatRepeatIgnoreSenderComponent>(radioSource));  // Persistence: Chat stacking from RMC14 - pull/7587
         var chatMsg = new MsgChatMessage { Message = chat };

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -1,12 +1,9 @@
 using Content.Server.Administration.Logs;
-using Content.Server.Chat.Managers; // Persistence: Chat stacking from RMC14 - pull/7587
 using Content.Server.Chat.Managers;
 using Content.Server.Chat.Systems;
 using Content.Server.Ghost;
 using Content.Server.Power.Components;
-using Content.Server.Station.Systems;
 using Content.Shared._RMC14.Chat; // Persistence: Chat stacking from RMC14 - pull/7587
-using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Database;
 using Content.Shared.Radio;
@@ -33,7 +30,6 @@ public sealed partial class RadioSystem : SharedRadioSystem
     [Dependency] private IChatManager _chatManager = default!;
     [Dependency] private GhostSystem _ghost = default!;
     [Dependency] private EntityQuery<TelecomExemptComponent> _exemptQuery = default!;
-    [Dependency] private readonly IChatManager _chatManager = default!; // Persistence: Chat stacking from RMC14 - pull/7587
 
     // set used to prevent radio feedback loops.
     private readonly HashSet<string> _messages = new();

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -1,8 +1,12 @@
 using Content.Server.Administration.Logs;
+using Content.Server.Chat.Managers; // Persistence: Chat stacking from RMC14 - pull/7587
 using Content.Server.Chat.Managers;
 using Content.Server.Chat.Systems;
 using Content.Server.Ghost;
 using Content.Server.Power.Components;
+using Content.Server.Station.Systems;
+using Content.Shared._RMC14.Chat; // Persistence: Chat stacking from RMC14 - pull/7587
+using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Database;
 using Content.Shared.Radio;
@@ -29,6 +33,7 @@ public sealed partial class RadioSystem : SharedRadioSystem
     [Dependency] private IChatManager _chatManager = default!;
     [Dependency] private GhostSystem _ghost = default!;
     [Dependency] private EntityQuery<TelecomExemptComponent> _exemptQuery = default!;
+    [Dependency] private readonly IChatManager _chatManager = default!; // Persistence: Chat stacking from RMC14 - pull/7587
 
     // set used to prevent radio feedback loops.
     private readonly HashSet<string> _messages = new();
@@ -110,7 +115,8 @@ public sealed partial class RadioSystem : SharedRadioSystem
             message,
             wrappedMessage,
             NetEntity.Invalid,
-            null);
+            _chatManager.EnsurePlayer(CompOrNull<ActorComponent>(messageSource)?.PlayerSession.UserId)?.Key,  // Persistence: Chat stacking from RMC14 - pull/7587
+            repeatCheckSender: !HasComp<ChatRepeatIgnoreSenderComponent>(radioSource));  // Persistence: Chat stacking from RMC14 - pull/7587
         var chatMsg = new MsgChatMessage { Message = chat };
         var ev = new RadioReceiveEvent(message, messageSource, channel, radioSource, chatMsg);
 

--- a/Content.Server/Telephone/TelephoneSystem.cs
+++ b/Content.Server/Telephone/TelephoneSystem.cs
@@ -1,8 +1,10 @@
 using Content.Server.Access.Systems;
 using Content.Server.Administration.Logs;
+using Content.Server.Chat.Managers; // Persistence: Chat stacking from RMC14 - pull/7587
 using Content.Server.Chat.Systems;
 using Content.Server.Interaction;
 using Content.Server.Power.EntitySystems;
+using Content.Shared._RMC14.Chat; // Persistence: Chat stacking from RMC14 - pull/7587
 using Content.Shared.Chat;
 using Content.Shared.Database;
 using Content.Shared.Labels.Components;
@@ -15,6 +17,10 @@ using Content.Shared.Speech.Components;
 using Content.Shared.Telephone;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Player; // Persistence: Chat stacking from RMC14 - pull/7587
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Replays;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Robust.Shared.Random;
@@ -34,6 +40,7 @@ public sealed partial class TelephoneSystem : SharedTelephoneSystem
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IAdminLogManager _adminLogger = default!;
     [Dependency] private IReplayRecordingManager _replay = default!;
+    [Dependency] private IChatManager _chatManager = default!; // Persistence: Chat stacking from RMC14 - pull/7587
 
     // Has set used to prevent telephone feedback loops
     private HashSet<(EntityUid, string, Entity<TelephoneComponent>)> _recentChatMessages = new();
@@ -384,8 +391,9 @@ public sealed partial class TelephoneSystem : SharedTelephoneSystem
             ChatChannel.Local,
             message,
             wrappedMessage,
-            NetEntity.Invalid,
-            null);
+            GetNetEntity(messageSource), // Persistence: Chat stacking from RMC14 - pull/7587
+            _chatManager.EnsurePlayer(CompOrNull<ActorComponent>(messageSource)?.PlayerSession.UserId)?.Key, // Persistence: Chat stacking from RMC14 - pull/7587
+            repeatCheckSender: !HasComp<ChatRepeatIgnoreSenderComponent>(source)); // Persistence: Chat stacking from RMC14 - pull/7587
 
         var chatMsg = new MsgChatMessage { Message = chat };
 

--- a/Content.Server/Telephone/TelephoneSystem.cs
+++ b/Content.Server/Telephone/TelephoneSystem.cs
@@ -18,9 +18,6 @@ using Content.Shared.Telephone;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player; // Persistence: Chat stacking from RMC14 - pull/7587
-using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
-using Robust.Shared.Replays;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Robust.Shared.Random;

--- a/Content.Shared/Chat/MsgChatMessage.cs
+++ b/Content.Shared/Chat/MsgChatMessage.cs
@@ -38,10 +38,12 @@ namespace Content.Shared.Chat
         public string? AudioPath;
         public float AudioVolume;
 
+        public bool RepeatCheckSender; // Persistence: Chat stacking from RMC14 - pull/7587
+
         [NonSerialized]
         public bool Read;
 
-        public ChatMessage(ChatChannel channel, string message, string wrappedMessage, NetEntity source, int? senderKey, bool hideChat = false, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0)
+        public ChatMessage(ChatChannel channel, string message, string wrappedMessage, NetEntity source, int? senderKey, bool hideChat = false, Color? colorOverride = null, string? audioPath = null, float audioVolume = 0, bool repeatCheckSender = true) // Persistence: Chat stacking from RMC14 - pull/7587
         {
             Channel = channel;
             Message = message;
@@ -52,6 +54,7 @@ namespace Content.Shared.Chat
             MessageColorOverride = colorOverride;
             AudioPath = audioPath;
             AudioVolume = audioVolume;
+            RepeatCheckSender = repeatCheckSender; // Persistence: Chat stacking from RMC14 - pull/7587
         }
 
         public ChatMessage(ChatMessage copyFrom)

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared;
+using Robust.Shared;
 using Robust.Shared.Configuration;
 
 namespace Content.Shared._RMC14.CCVar;
@@ -23,4 +23,8 @@ public sealed class RMCCVars : CVars
 
     public static readonly CVarDef<float> RMCMentorChatVolume =
         CVarDef.Create("rmc.mentor_help_volume", -5f, CVar.ARCHIVE | CVar.CLIENT | CVar.REPLICATED);
+
+    // Persistence: Chat stacking from RMC14 - pull/7587
+    public static readonly CVarDef<int> RMCChatRepeatHistory =
+        CVarDef.Create("rmc.chat_repeat_history", 4, CVar.REPLICATED | CVar.SERVER);
 }

--- a/Content.Shared/_RMC14/Chat/ChatRepeatIgnoreSenderComponent.cs
+++ b/Content.Shared/_RMC14/Chat/ChatRepeatIgnoreSenderComponent.cs
@@ -1,0 +1,7 @@
+﻿// Persistence: Chat stacking from RMC14 - pull/7587
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Chat;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ChatRepeatIgnoreSenderComponent : Component;


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
This PR adds chat stacking, making repeated messages combine into one with a multiplier rather than clog the chat window.

It's a cherry-pick of [this PR](https://github.com/michaelchessall/SS14-Persistence/pull/568) from [Persistence](https://github.com/michaelchessall/SS14-Persistence), because it was far far easier than untangling [the original PR from RMC](https://github.com/RMC-14/RMC-14/pull/7587), which was tied in with several other things. Persistence is MIT and are cool. :yum:
<!-- What did you change? -->

### How to enable / disable
Revert this, but I highly recommend keeping it.
<!--
    According to our Conventions, all new content added should be easy for a downstream to disable or opt-out of.
    Content can be opt-out (or opt-in) through the use of CVars, simple YML changes, or simply by not using a feature (if it is made optional in some way, like a mapped entity or an admin-only commmand).

    Explain below how to enable or disable this content. If this is a bugfix, tweak, or a "non-content" change,
    this section can be omitted.
-->

## Why / Balance
Make chat and emote spam less annoying, while still allowing it to place the emphasis of repetition.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
See original PRs.
<!-- Summary of code changes for easier review. -->

## Test plan
Localhost, spam messages. See them stack. 
Admin chat, spam messages. They shouldn't stack. None of the admin related messages stack.
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media

https://github.com/user-attachments/assets/d163366d-a482-4132-b6e8-6749966e9e5a


<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->

## Changelog
:cl: DrSmugleaf, stinkiestdog, AraiMaia
- add: Ported chat stacking from RMC! Thank you DrSmugleaf!
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
