### PR TITLE
Fix chemvend

### DIFF
--- a/Content.Client/_Funkystation/VendingMachines/UI/VendingMachineGridSlot.xaml.cs
+++ b/Content.Client/_Funkystation/VendingMachines/UI/VendingMachineGridSlot.xaml.cs
@@ -14,6 +14,7 @@ public sealed partial class VendingMachineGridSlot : PanelContainer
 {
     [Dependency] private IPrototypeManager _protoManager = null!;
     [Dependency] private ILocalizationManager _loc = null!;
+    [Dependency] private IComponentFactory _componentFactory = default!;
 
     private const float SlotSize = 84f;
     private const float ItemSize = 64f;
@@ -67,22 +68,7 @@ public sealed partial class VendingMachineGridSlot : PanelContainer
 
         if (_protoManager.TryIndex(protoId, out var proto))
         {
-            var tooltipText = proto.Name;
-
-            if (proto.Components.TryGetValue("Label", out var labelEntry) &&
-                labelEntry.Component is LabelComponent label &&
-                !string.IsNullOrWhiteSpace(label.CurrentLabel))
-            {
-                var labelText = _loc.TryGetString(label.CurrentLabel, out var localized)
-                    ? localized
-                    : label.CurrentLabel;
-
-                tooltipText = $"{proto.Name} ({labelText})";
-            }
-
-            ToolTip = string.IsNullOrWhiteSpace(proto.Description)
-                ? tooltipText
-                : $"{tooltipText}\n{proto.Description}";
+            ToolTip = GetItemText(proto);
         }
 
         SetAmount(amount, soldOut);
@@ -153,5 +139,21 @@ public sealed partial class VendingMachineGridSlot : PanelContainer
 
             ApplySoldOutState(_pendingSoldOut);
         }
+    }
+
+    private string GetItemText(EntityPrototype prototype)
+    {
+        var itemName = prototype.Name;
+
+        if (prototype.TryComp<LabelComponent>(out var label, _componentFactory) &&
+            label.LocalizedLabel is { } locId)
+        {
+            itemName = _loc.GetString("comp-label-format",
+                ("baseName", itemName),
+                ("label", _loc.GetString(locId)));
+        }
+        return string.IsNullOrWhiteSpace(prototype.Description)
+            ? itemName
+            : $"{itemName}\n{prototype.Description}";
     }
 }


### PR DESCRIPTION
## About the PR
Fixes vending machines not showing item labels properly

## Why / Balance
Less annoying than memorizing colors

## Technical details
`CurrentLabel` is only set after init, `LocalizedLabel` is correct for prototypes. Additionally I pulled in the item label localization key, for parity with the original ui.

## Test plan
Open chem vend
Hover over an entry until the tooltip shows up
Observe that the label is there

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
<img width="550" height="148" alt="image" src="https://github.com/user-attachments/assets/5ea5f95b-02d5-4275-8938-d7dfad60e01e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## License
MIT

## Changelog
:cl:
- fix: Fixed vending machines not showing labels.
