### PR TITLE
Customizable interaction outlines

### DIFF
--- a/Content.Client/Interaction/DragDropSystem.cs
+++ b/Content.Client/Interaction/DragDropSystem.cs
@@ -50,6 +50,8 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
     [Dependency] private SpriteSystem _sprite = default!;
     [Dependency] private EntityQuery<SpriteComponent> _spriteQuery = default!;
 
+    private ISawmill? _dragDropSawmill; // funky
+
     // how often to recheck possible targets (prevents calling expensive
     // check logic each update)
     private const float TargetRecheckInterval = 0.25f;
@@ -119,6 +121,8 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
         CommandBinds.Builder
             .BindBefore(EngineKeyFunctions.Use, new PointerInputCmdHandler(OnUse, false, true), new[] { typeof(SharedInteractionSystem) })
             .Register<DragDropSystem>();
+
+        _dragDropSawmill = LogManager.GetSawmill("drag_drop"); // funky
     }
 
     private void SetDeadZone(float deadZone)
@@ -456,6 +460,14 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
                         && _interactionSystem.InRangeUnobstructed(user.Value, entity);
             }
 
+            // funky start
+            if (OutlineColor.TryGetOutlineColor(true, out var validColor, _cfgMan, _dragDropSawmill))
+                _dropTargetInRangeShader?.SetParameter("outline_color", validColor);
+
+            if (OutlineColor.TryGetOutlineColor(false, out var invalidColor, _cfgMan, _dragDropSawmill))
+                _dropTargetOutOfRangeShader?.SetParameter("outline_color", invalidColor);
+            // funky end
+
             // highlight depending on whether its in or out of range
             SetDragDropPostShader((entity, inRangeSprite), valid.Value ? _dropTargetInRangeShader! : _dropTargetOutOfRangeShader!);
             inRangeSprite.RenderOrder = EntityManager.CurrentTick.Value;
@@ -550,14 +562,6 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
-
-        // funky start
-        if (OutlineColor.TryGetOutlineColor(true, out var validColor, _cfgMan))
-            _dropTargetInRangeShader?.SetParameter("outline_color", validColor);
-
-        if (OutlineColor.TryGetOutlineColor(false, out var invalidColor, _cfgMan))
-            _dropTargetOutOfRangeShader?.SetParameter("outline_color", invalidColor);
-        // funky end
 
         switch (_state)
         {

--- a/Content.Client/Interaction/DragDropSystem.cs
+++ b/Content.Client/Interaction/DragDropSystem.cs
@@ -113,8 +113,8 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
 
         Subs.CVar(_cfgMan, CCVars.DragDropDeadZone, SetDeadZone, true);
 
-        _dropTargetInRangeShader = ProtoMan.Index(ShaderDropTargetInRange).Instance();
-        _dropTargetOutOfRangeShader = ProtoMan.Index(ShaderDropTargetOutOfRange).Instance();
+        _dropTargetInRangeShader = ProtoMan.Index(ShaderDropTargetInRange).InstanceUnique(); // funky - get mutable instance
+        _dropTargetOutOfRangeShader = ProtoMan.Index(ShaderDropTargetOutOfRange).InstanceUnique(); // funky - get mutable instance
         // needs to fire on mouseup and mousedown so we can detect a drag / drop
         CommandBinds.Builder
             .BindBefore(EngineKeyFunctions.Use, new PointerInputCmdHandler(OnUse, false, true), new[] { typeof(SharedInteractionSystem) })
@@ -550,6 +550,14 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
+
+        // funky start
+        if (OutlineColor.TryGetOutlineColor(true, out var validColor, _cfgMan))
+            _dropTargetInRangeShader?.SetParameter("outline_color", validColor);
+
+        if (OutlineColor.TryGetOutlineColor(false, out var invalidColor, _cfgMan))
+            _dropTargetOutOfRangeShader?.SetParameter("outline_color", invalidColor);
+        // funky end
 
         switch (_state)
         {

--- a/Content.Client/Options/UI/OptionColorSlider.xaml
+++ b/Content.Client/Options/UI/OptionColorSlider.xaml
@@ -3,6 +3,6 @@
         <Label Name="TitleLabel" Access="Public" />
         <Label Name="ExampleLabel" Access="Public" />
         <ColorSelectorSliders Name="Slider" Access="Public" HorizontalExpand="True" />
-        <Button Name="ResetDefaults" Access="Public" Text="Reset to default"/> <!-- funky -->
+        <Button Name="ResetDefaults" Access="Public" Text="{Loc 'ui-options-color-slider-default-button'}"/> <!-- funky -->
     </BoxContainer>
 </Control>

--- a/Content.Client/Options/UI/OptionColorSlider.xaml
+++ b/Content.Client/Options/UI/OptionColorSlider.xaml
@@ -3,5 +3,6 @@
         <Label Name="TitleLabel" Access="Public" />
         <Label Name="ExampleLabel" Access="Public" />
         <ColorSelectorSliders Name="Slider" Access="Public" HorizontalExpand="True" />
+        <Button Name="ResetDefaults" Access="Public" Text="Reset to default"/> <!-- funky -->
     </BoxContainer>
 </Control>

--- a/Content.Client/Options/UI/OptionsTabControlRow.xaml.cs
+++ b/Content.Client/Options/UI/OptionsTabControlRow.xaml.cs
@@ -544,7 +544,7 @@ public sealed class OptionColorSliderCVar : BaseOptionCVar<string>
         get => _slider.Slider.Color.ToHex();
         set
         {
-            _slider.Slider.Color = Color.FromHex(value);
+            _slider.Slider.Color = Color.FromHex(value, Color.Black); // funky - add fallback
             UpdateLabelColor();
         }
     }
@@ -575,6 +575,14 @@ public sealed class OptionColorSliderCVar : BaseOptionCVar<string>
             ValueChanged();
             UpdateLabelColor();
         };
+
+        // funky start - add button to reset to default colors
+        slider.ResetDefaults.OnPressed += _ =>
+        {
+            Value = cVar.DefaultValue;
+            ValueChanged();
+        };
+        // funky end
     }
 
     private void UpdateLabelColor()

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -53,6 +53,17 @@
                 <ui:OptionColorSlider Name="HighlightsColorSlider"
                     Title="{Loc 'ui-options-highlights-color'}"
                     Example="{Loc 'ui-options-highlights-color-example'}"/>
+                <!-- funky interaction outline custom setting -->
+                <!-- breaking up with labels to help visually distinguish the options better -->
+                <Label Text="{Loc 'ui-options-interaction-outline-valid'}"
+                       StyleClasses="LabelKeyText"/>
+                <ui:OptionColorSlider Name="ValidInteractionOutlineColorSlider"
+                                      Example="{Loc 'ui-options-interaction-color-example'}"/>
+                <Label Text="{Loc 'ui-options-interaction-outline-invalid'}"
+                       StyleClasses="LabelKeyText"/>
+                <ui:OptionColorSlider Name="InvalidInteractionOutlineColorSlider"
+                                      Example="{Loc 'ui-options-interaction-color-example'}"/>
+                <!-- funky interaction outline custom setting end -->
                 <Label Text="{Loc 'ui-options-accessibility-header-content'}"
                        StyleClasses="LabelKeyText"/>
                 <CheckBox Name="CensorNudityCheckBox" Text="{Loc 'ui-options-censor-nudity'}" />

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -36,6 +36,13 @@ public sealed partial class AccessibilityTab : Control
         Control.AddOptionCheckBox(CCVars.ChatAutoFillHighlights, AutoFillHighlightsCheckBox);
         Control.AddOptionColorSlider(CCVars.ChatHighlightsColor, HighlightsColorSlider);
 
+        // funky start
+        Control.AddOptionColorSlider(InteractionOutlineCVars.ValidInteractionOutlineColor,
+            ValidInteractionOutlineColorSlider);
+        Control.AddOptionColorSlider(InteractionOutlineCVars.InvalidInteractionOutlineColor,
+            InvalidInteractionOutlineColorSlider);
+        // funky end
+
         Control.AddOptionCheckBox(CCVars.AccessibilityClientCensorNudity, CensorNudityCheckBox);
 
         Control.Initialize();

--- a/Content.Client/Outline/InteractionOutlineSystem.cs
+++ b/Content.Client/Outline/InteractionOutlineSystem.cs
@@ -35,6 +35,8 @@ public sealed partial class InteractionOutlineSystem : EntitySystem
     [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private SpriteSystem _sprite = default!;
 
+    private ISawmill? _interactionOutlineSawmill; // funky
+
     /// <summary>
     ///     Whether to currently draw the outline. The outline may be temporarily disabled by other systems
     /// </summary>
@@ -65,6 +67,8 @@ public sealed partial class InteractionOutlineSystem : EntitySystem
         Subs.CVar(_configManager, CCVars.OutlineEnabled, SetCvarEnabled);
         SubscribeLocalEvent<InteractionOutlineComponent, ComponentShutdown>(OnShutdown);
         UpdatesAfter.Add(typeof(SharedEyeSystem));
+
+        _interactionOutlineSawmill = LogManager.GetSawmill("interactionoutline");
     }
 
     private void OnShutdown(Entity<InteractionOutlineComponent> ent, ref ComponentShutdown args)
@@ -238,6 +242,13 @@ public sealed partial class InteractionOutlineSystem : EntitySystem
         {
             return;
         }
+
+        // funky start
+        if (OutlineColor.TryGetOutlineColor(inRange, out var outlineColor, _configManager, _interactionOutlineSawmill))
+        {
+            shader.SetParameter("outline_color", outlineColor);
+        }
+        // funky end
 
         _sprite.SetPostShader(sprite, new SpriteComponent.PostShaderArgs(ContentPostShaderIds.InteractionOutline, shader)
         {

--- a/Content.Client/Outline/InteractionOutlineSystem.cs
+++ b/Content.Client/Outline/InteractionOutlineSystem.cs
@@ -68,7 +68,7 @@ public sealed partial class InteractionOutlineSystem : EntitySystem
         SubscribeLocalEvent<InteractionOutlineComponent, ComponentShutdown>(OnShutdown);
         UpdatesAfter.Add(typeof(SharedEyeSystem));
 
-        _interactionOutlineSawmill = LogManager.GetSawmill("interactionoutline");
+        _interactionOutlineSawmill = LogManager.GetSawmill("interaction_outline"); // funky
     }
 
     private void OnShutdown(Entity<InteractionOutlineComponent> ent, ref ComponentShutdown args)

--- a/Content.Client/Outline/TargetOutlineSystem.cs
+++ b/Content.Client/Outline/TargetOutlineSystem.cs
@@ -91,7 +91,7 @@ public sealed partial class TargetOutlineSystem : EntitySystem
         _shaderTargetValid = ProtoMan.Index(ShaderTargetValid).InstanceUnique();
         _shaderTargetInvalid = ProtoMan.Index(ShaderTargetInvalid).InstanceUnique();
 
-        _targetOutlineSawmill = LogManager.GetSawmill("targetoutline"); // funky
+        _targetOutlineSawmill = LogManager.GetSawmill("target_outline"); // funky
     }
 
     public void Disable()
@@ -121,14 +121,6 @@ public sealed partial class TargetOutlineSystem : EntitySystem
 
         if (!_enabled || !_timing.IsFirstTimePredicted)
             return;
-
-        // funky start
-        if (OutlineColor.TryGetOutlineColor(true, out var validColor, _cfg, _targetOutlineSawmill))
-            _shaderTargetValid?.SetParameter("outline_color", validColor);
-
-        if (OutlineColor.TryGetOutlineColor(false, out var invalidColor, _cfg, _targetOutlineSawmill))
-            _shaderTargetInvalid?.SetParameter("outline_color", invalidColor);
-        // funky end
 
         HighlightTargets();
     }
@@ -188,6 +180,14 @@ public sealed partial class TargetOutlineSystem : EntitySystem
                 var target = _transformSystem.GetWorldPosition(entity);
                 valid = (origin - target).LengthSquared() <= Range;
             }
+
+            // funky start
+            if (OutlineColor.TryGetOutlineColor(true, out var validColor, _cfg, _targetOutlineSawmill))
+                _shaderTargetValid?.SetParameter("outline_color", validColor);
+
+            if (OutlineColor.TryGetOutlineColor(false, out var invalidColor, _cfg, _targetOutlineSawmill))
+                _shaderTargetInvalid?.SetParameter("outline_color", invalidColor);
+            // funky end
 
             // highlight depending on whether its in or out of range
             _sprite.SetPostShader(sprite, new SpriteComponent.PostShaderArgs(ContentPostShaderIds.TargetOutline, valid ? _shaderTargetValid! : _shaderTargetInvalid!)

--- a/Content.Client/Outline/TargetOutlineSystem.cs
+++ b/Content.Client/Outline/TargetOutlineSystem.cs
@@ -6,6 +6,7 @@ using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.Player;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -29,6 +30,9 @@ public sealed partial class TargetOutlineSystem : EntitySystem
     [Dependency] private SharedTransformSystem _transformSystem = default!;
     [Dependency] private EntityQuery<SpriteComponent> _spriteQuery = default!;
     [Dependency] private SpriteSystem _sprite = default!;
+    [Dependency] private IConfigurationManager _cfg = null!; // funky
+
+    private ISawmill? _targetOutlineSawmill; // funky
 
     private bool _enabled = false;
 
@@ -86,6 +90,8 @@ public sealed partial class TargetOutlineSystem : EntitySystem
 
         _shaderTargetValid = ProtoMan.Index(ShaderTargetValid).InstanceUnique();
         _shaderTargetInvalid = ProtoMan.Index(ShaderTargetInvalid).InstanceUnique();
+
+        _targetOutlineSawmill = LogManager.GetSawmill("targetoutline"); // funky
     }
 
     public void Disable()
@@ -115,6 +121,14 @@ public sealed partial class TargetOutlineSystem : EntitySystem
 
         if (!_enabled || !_timing.IsFirstTimePredicted)
             return;
+
+        // funky start
+        if (OutlineColor.TryGetOutlineColor(true, out var validColor, _cfg, _targetOutlineSawmill))
+            _shaderTargetValid?.SetParameter("outline_color", validColor);
+
+        if (OutlineColor.TryGetOutlineColor(false, out var invalidColor, _cfg, _targetOutlineSawmill))
+            _shaderTargetInvalid?.SetParameter("outline_color", invalidColor);
+        // funky end
 
         HighlightTargets();
     }

--- a/Content.Client/_Funkystation/Outline/OutlineColor.cs
+++ b/Content.Client/_Funkystation/Outline/OutlineColor.cs
@@ -13,7 +13,7 @@ public static class OutlineColor
     public static bool TryGetOutlineColor(bool inRange, out Color outlineColor, IConfigurationManager? configManager = null, ISawmill? sawmill = null)
     {
         configManager ??= IoCManager.Resolve<IConfigurationManager>();
-        sawmill ??= IoCManager.Resolve<ILogManager>().GetSawmill("outlinecolor");
+        sawmill ??= IoCManager.Resolve<ILogManager>().GetSawmill("outline_color");
 
         var colorCvar = inRange
         ? InteractionOutlineCVars.ValidInteractionOutlineColor

--- a/Content.Client/_Funkystation/Outline/OutlineColor.cs
+++ b/Content.Client/_Funkystation/Outline/OutlineColor.cs
@@ -1,0 +1,33 @@
+using Content.Shared._Funkystation.CCVar;
+using Robust.Shared.Configuration;
+
+namespace Content.Client.Outline;
+
+public static class OutlineColor
+{
+    /// <summary>
+    /// Gets the relevant interaction outline color based on the client's outline color CVars.
+    /// </summary>
+    /// <param name="inRange">Whether the thing we're getting the outline for is in-range or out-of-range.</param>
+    /// <returns>True if the cvar was set to a valid hex color.</returns>
+    public static bool TryGetOutlineColor(bool inRange, out Color outlineColor, IConfigurationManager? configManager = null, ISawmill? sawmill = null)
+    {
+        configManager ??= IoCManager.Resolve<IConfigurationManager>();
+        sawmill ??= IoCManager.Resolve<ILogManager>().GetSawmill("outlinecolor");
+
+        var colorCvar = inRange
+        ? InteractionOutlineCVars.ValidInteractionOutlineColor
+        : InteractionOutlineCVars.InvalidInteractionOutlineColor;
+
+        var color = configManager.GetCVar(colorCvar);
+
+        if (!Color.TryFromHex(color, out outlineColor))
+        {
+            sawmill.Warning($"{colorCvar.Name} is set to an invalid color ({color}).");
+            if (!Color.TryFromHex(colorCvar.DefaultValue, out outlineColor))
+                sawmill.Error($"{colorCvar.Name} has an invalid default value ({colorCvar.DefaultValue}).");
+            return false;
+        }
+        return true;
+    }
+}

--- a/Content.Shared/_Funkystation/CCVar/InteractionOutlineCVars.cs
+++ b/Content.Shared/_Funkystation/CCVar/InteractionOutlineCVars.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._Funkystation.CCVar;
+
+[CVarDefs]
+public sealed class InteractionOutlineCVars
+{
+    // colors based on colors from https://github.com/funky-station/forky-station/commit/cb9b846a8bc6849a04e54228007eca5ff11d1e13
+    public static readonly CVarDef<string> ValidInteractionOutlineColor = CVarDef.Create(
+        "funkystation.interaction_outline.valid", "#d0ffea", CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<string> InvalidInteractionOutlineColor = CVarDef.Create(
+        "funkystation.interaction_outline.invalid", "#e64659", CVar.CLIENTONLY | CVar.ARCHIVE);
+}

--- a/Content.Shared/_Funkystation/CCVar/InteractionOutlineCVars.cs
+++ b/Content.Shared/_Funkystation/CCVar/InteractionOutlineCVars.cs
@@ -5,7 +5,7 @@ namespace Content.Shared._Funkystation.CCVar;
 [CVarDefs]
 public sealed class InteractionOutlineCVars
 {
-    // colors based on colors from https://github.com/funky-station/forky-station/commit/cb9b846a8bc6849a04e54228007eca5ff11d1e13
+    // default colors based on colors from https://github.com/funky-station/forky-station/commit/cb9b846a8bc6849a04e54228007eca5ff11d1e13
     public static readonly CVarDef<string> ValidInteractionOutlineColor = CVarDef.Create(
         "funkystation.interaction_outline.valid", "#d0ffea", CVar.CLIENTONLY | CVar.ARCHIVE);
 

--- a/Content.Shared/_Funkystation/CCVar/InteractionOutlineCVars.cs
+++ b/Content.Shared/_Funkystation/CCVar/InteractionOutlineCVars.cs
@@ -7,8 +7,8 @@ public sealed class InteractionOutlineCVars
 {
     // default colors based on colors from https://github.com/funky-station/forky-station/commit/cb9b846a8bc6849a04e54228007eca5ff11d1e13
     public static readonly CVarDef<string> ValidInteractionOutlineColor = CVarDef.Create(
-        "funkystation.interaction_outline.valid", "#d0ffea", CVar.CLIENTONLY | CVar.ARCHIVE);
+        "funkystation.interaction_outline.in_range_color", "#d0ffea", CVar.CLIENTONLY | CVar.ARCHIVE);
 
     public static readonly CVarDef<string> InvalidInteractionOutlineColor = CVarDef.Create(
-        "funkystation.interaction_outline.invalid", "#e64659", CVar.CLIENTONLY | CVar.ARCHIVE);
+        "funkystation.interaction_outline.out_of_range_color", "#e64659", CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -411,6 +411,7 @@ ui-options-viewcone-occlusion-opacity = Viewcone occlusion strength
 ui-options-interaction-outline-valid = Outline color for objects inside of interaction range
 ui-options-interaction-outline-invalid = Outline color for objects outside of interaction range
 ui-options-interaction-color-example = This is the outline color.
+ui-options-color-slider-default-button = Reset to default
 
 ui-options-chat-window-opacity = Chat window opacity
 ui-options-speech-bubble-text-opacity = Speech bubble text opacity

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -407,6 +407,11 @@ ui-options-es-pain-flash-intensity = Pain flash intensity
 ui-options-disable-viewcone-grain = Disable the grain effect on the viewcone occlusion overlay
 ui-options-viewcone-occlusion-opacity = Viewcone occlusion strength
 
+# funky custom interaction outlines
+ui-options-interaction-outline-valid = Outline color for objects inside of interaction range
+ui-options-interaction-outline-invalid = Outline color for objects outside of interaction range
+ui-options-interaction-color-example = This is the outline color.
+
 ui-options-chat-window-opacity = Chat window opacity
 ui-options-speech-bubble-text-opacity = Speech bubble text opacity
 ui-options-speech-bubble-speaker-opacity = Speech bubble speaker opacity


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
<!-- What did you change? -->
Added two options to the accessibility tab of player settings to change the interaction outline for objects.
Also implemented a "reset to default" button for color related options.
### How to enable / disable
<!--
    According to our Conventions, all new content added should be easy for a downstream to disable or opt-out of.
    Content can be opt-out (or opt-in) through the use of CVars, simple YML changes, or simply by not using a feature (if it is made optional in some way, like a mapped entity or an admin-only commmand).

    Explain below how to enable or disable this content. If this is a bugfix, tweak, or a "non-content" change,
    this section can be omitted.
-->
i'll probably be upstreaming this. for now, just revert it. it should probably also be reverted if i do successfully get this merged upstream when it comes time to upmerge?

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
inspired by https://github.com/funky-station/forky-station/pull/424, and its a worthwhile accessibility option. plenty of other things are customizable, why not this?
## Technical details
<!-- Summary of code changes for easier review. -->
- added a button to OptionColorSlider that resets the value to the related Cvar's default value and added a fallback to OptionColorSlider if its provided an invalid hex value.
- added two client cvars which store the hex values for valid and invalid interaction outline colors.
- implemented a static OutlineColor class whose purpose is to contain a static function which gets either the valid or invalid interaction color from the cvars and check that the value it got back is a valid hex value, and do some logging if it isn't.
- used this function in InteractionOutlineSystem, TargetOutlineSystem, and DragDropSystem to update the colors of the outlines. each of these systems uses its own sawmill for logging when the color provided is invalid partly because I don't want to accidentally resolve a dependency every update but also for clarity
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
check that your colors are correct defaults and the console isnt getting errors from interaction outlines
open accessibility options, change your colors and see that they changed correctly
click reset to default on each color and make sure it correctly returned to its default value
manually change either "funkystation.interaction_outline" cvar to something that isnt a hex value
make sure this invalid value is logged correctly when you hover stuff
reopen accessibility options and make sure the color slider for the cvar you changed has fallen back to black

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
[interactiondemo.webm](https://github.com/user-attachments/assets/7e32cc5d-aff6-4436-b4fb-04cf8f7c1867)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [ ] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->
Accessibility tab of options has two new color sliders. Also, OptionColorSlider now has an extra button for resetting the value to cvar's default.
DragDropSystem now gets unique, mutable instances of outline shaders instead of shared, immutable instances.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Made the color of interaction outlines on objects customizable via the accessibility tab in the player's options.
- add: Added a "Reset to default" button to color sliders in the player's options.