### PR TITLE
Larger area behind player is visible through viewcone

### DIFF
--- a/Content.Shared/_ES/Viewcone/Components/ESViewconeComponent.cs
+++ b/Content.Shared/_ES/Viewcone/Components/ESViewconeComponent.cs
@@ -45,7 +45,6 @@ public sealed partial class ESViewconeComponent : Component
     [DataField, AutoNetworkedField]
     public float ConeFeather = 10f;
 
-
     [DataField, AutoNetworkedField]
     public float ConeIgnoreRadius = 1f; //Funky 0.5f -> 1f
 

--- a/Content.Shared/_ES/Viewcone/Components/ESViewconeComponent.cs
+++ b/Content.Shared/_ES/Viewcone/Components/ESViewconeComponent.cs
@@ -46,7 +46,7 @@ public sealed partial class ESViewconeComponent : Component
     public float ConeFeather = 10f;
 
     [DataField, AutoNetworkedField]
-    public float ConeIgnoreRadius = 0.5f;
+    public float ConeIgnoreRadius = 1f;
 
     [DataField, AutoNetworkedField]
     public float ConeIgnoreFeather = 0.08f;

--- a/Content.Shared/_ES/Viewcone/Components/ESViewconeComponent.cs
+++ b/Content.Shared/_ES/Viewcone/Components/ESViewconeComponent.cs
@@ -45,8 +45,9 @@ public sealed partial class ESViewconeComponent : Component
     [DataField, AutoNetworkedField]
     public float ConeFeather = 10f;
 
+
     [DataField, AutoNetworkedField]
-    public float ConeIgnoreRadius = 1f;
+    public float ConeIgnoreRadius = 1f; //Funky 0.5f -> 1f
 
     [DataField, AutoNetworkedField]
     public float ConeIgnoreFeather = 0.08f;


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
<!-- What did you change? -->
I increased the area behind the player that wasn't blocked by the viewcone.
### How to enable / disable
<!--
    According to our Conventions, all new content added should be easy for a downstream to disable or opt-out of.
    Content can be opt-out (or opt-in) through the use of CVars, simple YML changes, or simply by not using a feature (if it is made optional in some way, like a mapped entity or an admin-only commmand).

    Explain below how to enable or disable this content. If this is a bugfix, tweak, or a "non-content" change,
    this section can be omitted.
-->
Change the variable ConeIgnoreRadius back to 0.5f in ESViewconeComponent.cs
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's really awkward to be in a small room and you have to actively rotate all the way around to pick something up off a table/floor. Same thing with halls/etc. Also, it's more realistic. People have an intuition about what's directly around them (e.g. other people being directly behind them). No more skyrim NPCing lol.
## Technical details
<!-- Summary of code changes for easier review. -->
Changing a variable... woo. 
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Load game
viewcone is different
celebrate
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
<img width="937" height="711" alt="image" src="https://github.com/user-attachments/assets/8aea70ce-a7c7-498a-b4c1-89917a12f94b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [N/A] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->
This shouldn't break anything. 
## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Changed radius around player that can be seen through the viewcone. 
