### PR TITLE
Fix - Give prisoners breathable gas in loadout

### DIFF
--- a/Resources/Prototypes/_Funkystation/Loadouts/RoleLoadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Funkystation/Loadouts/RoleLoadouts/role_loadouts.yml
@@ -147,5 +147,6 @@
   groups:
   - Glasses
   - Trinkets
+  - Survival
   - GroupSpeciesBreathTool
   - GroupBreathToolDecapoid # MACRO: Decapoid

--- a/Resources/Prototypes/_Funkystation/Loadouts/RoleLoadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Funkystation/Loadouts/RoleLoadouts/role_loadouts.yml
@@ -148,5 +148,6 @@
   - Glasses
   - Trinkets
   - Survival
+  - GroupTankHarness
   - GroupSpeciesBreathTool
   - GroupBreathToolDecapoid # MACRO: Decapoid


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
<!-- What did you change? -->
Added the Survival and GroupTankHarness LoadoutGroups to the Prisoner role loadout

### How to enable / disable
<!--
    According to our Conventions, all new content added should be easy for a downstream to disable or opt-out of.
    Content can be opt-out (or opt-in) through the use of CVars, simple YML changes, or simply by not using a feature (if it is made optional in some way, like a mapped entity or an admin-only commmand).

    Explain below how to enable or disable this content. If this is a bugfix, tweak, or a "non-content" change,
    this section can be omitted.
-->
Just remove the lines

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I assume this was not given to prisoners to not give them survival boxes, but these don't spawn anyway as prisoners don't have a backpack. This gives prisoners a gas tank if they need it, and gives Vox a harness to hold it.
If this is intentional behaviour, feel free to ignore this PR.

## Technical details
<!-- Summary of code changes for easier review. -->
Two lines of YAML

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Queue Prisoner roundstart as Decapoid
2. Upon round start, verify that the correct breathing tank is in your suit back slot
3. Repeat as Vox
4. Repeat with late join

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
<img width="1685" height="985" alt="image" src="https://github.com/user-attachments/assets/e038ab1d-d2aa-44d5-b6d2-00900e46dd09" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->

:cl: feymild
- fix: Gave non-oxygen breathing prisoners gas they need on round start

