### PR TITLE
Security Shutters

### DIFF
--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Doors/Shutters/shutters.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Doors/Shutters/shutters.yml
@@ -1,0 +1,24 @@
+- type: entity
+  parent: ShuttersWindow
+  id: ShuttersSecurityLocked
+  suffix: Security, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsSecurity ]
+  - type: AccessReader
+    containerAccessProvider: board
+
+- type: entity
+  parent: ShuttersSecurityLocked
+  id: ShuttersSecurityOpen
+  suffix: Security, open
+  components:
+  - type: Door
+    state: Open
+  - type: Physics
+    canCollide: false
+  - type: Airtight
+    airBlocked: false
+  - type: RadiationBlocker
+    enabled: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
<!-- What did you change? -->
This adds shutters that are access locked for use in security checkpoints and security hallway lockdown setups. Examples of how to setup both will be included.
### How to enable / disable
<!--
    According to our Conventions, all new content added should be easy for a downstream to disable or opt-out of.
    Content can be opt-out (or opt-in) through the use of CVars, simple YML changes, or simply by not using a feature (if it is made optional in some way, like a mapped entity or an admin-only commmand).

    Explain below how to enable or disable this content. If this is a bugfix, tweak, or a "non-content" change,
    this section can be omitted.
-->
Simply do not map them in
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This feels like a missing piece in being able to setup a variety of security checkpoints and enforcing securities ultimate control over movement throughout the stations hallways.
## Technical details
<!-- Summary of code changes for easier review. -->
Uses the same template as the centcom locked shutters but instead uses standard security access.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Add some in, link em up with a sec ID and lock the crew out then try to link them without a sec ID.
## Media and Setup
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
All of the logic gates used are XOR gates, they are the simplest solution but feel free to experiment.
### Hallway lockdown
<img width="572" height="291" alt="SecShutdown" src="https://github.com/user-attachments/assets/06c31415-9b84-4531-8621-a24543304525" />
This provides a simple way to lock down less important hallways. Anchor a XOR gate under a tile with a sec locked button on either side. Link the buttons to the inputs on the XOR gate and the XOR output to the shutters. This allows both buttons to independently toggle the status of the shutters

### Fully featured security checkpoint
<img width="772" height="546" alt="FullAirlockSetup" src="https://github.com/user-attachments/assets/81b493ac-4ac9-4751-b73d-29baf7694cb3" />
This is a more complex setup that is similar to the simple one but with an extra button for the control room. Link the first set of buttons in the top hallway section into the XOR inputs like normal then connect the XOR output and the control room button into the inputs of the second XOR gate and connect its output to the top shutters. Simply mirror for the bottom. Here is a crude example of a setup 
<img width="772" height="546" alt="FullAirlockSetupSetup" src="https://github.com/user-attachments/assets/6bec7056-99ef-49c1-8875-e72af5f9c0ae" />
This setup means all 3 top buttons independently operate the top set of doors and the bottom 3 do the same just for the bottom

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->
No breaking changes
## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Added security access locked shutters