### PR TITLE
Temporary fix for floating ghost follow buttons

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -124,16 +124,24 @@ public partial class ChatBox : UIWidget
         formatted.AddMarkupOrThrow(message);
         formatted.Pop();
 
+        // funky - just to avoid asking entManager for the system multiple times
         var cmChatSystem = _entManager.System<CMChatSystem>();
 
         // Persistence: Chat stacking from RMC14 - pull/7587
         if (cmChatSystem.TryRepetition(this, Contents, formatted, sender, unwrapped, channel, repeatCheckSender))
         {
+            // funky
+            // we can get away with getting the last GhostFollowLabel in the OutputPanel's contents because i'm pretty sure
+            // whenever a message with tags that get parsed into controls gets added or modified, those new controls are always
+            // sent to the bottom of the tree
+            // also, we can only do this after the message has been parsed which is partly why it happens separately from TryRepetition
             cmChatSystem.UpdateGhostFollowLink(this, Contents.GetControlOfType<GhostFollowLabel>().LastOrDefault(), sender, unwrapped, channel, repeatCheckSender);
             return;
         }
 
         Contents.AddMessage(formatted, tagsAllowed: null);
+        // funky - if there's a new ghost follow link, attach it to the new message in the repeat message queue
+        // we can only do this after the message has been parsed which is why it happens separately from TryRepetition
         cmChatSystem.AddGhostFollowLink(this, Contents.GetControlOfType<GhostFollowLabel>().LastOrDefault());
     }
 

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using Content.Client._Funkystation.UserInterface.Controls;
-using Content.Client._RMC14.Chat;
-using Content.Client.UserInterface.ControlExtensions; // Persistence: Chat stacking from RMC14 - pull/7587
+using Content.Client._RMC14.Chat; // Persistence: Chat stacking from RMC14 - pull/7587
+using Content.Client.UserInterface.ControlExtensions;
 using Content.Client.UserInterface.Systems.Chat.Controls;
 using Content.Shared.Chat;
 using Content.Shared.Input;
@@ -124,12 +124,17 @@ public partial class ChatBox : UIWidget
         formatted.AddMarkupOrThrow(message);
         formatted.Pop();
 
+        var cmChatSystem = _entManager.System<CMChatSystem>();
+
         // Persistence: Chat stacking from RMC14 - pull/7587
-        if (_entManager.System<CMChatSystem>().TryRepetition(this, Contents, formatted, sender, unwrapped, channel, repeatCheckSender))
+        if (cmChatSystem.TryRepetition(this, Contents, formatted, sender, unwrapped, channel, repeatCheckSender))
+        {
+            cmChatSystem.UpdateGhostFollowLink(this, Contents.GetControlOfType<GhostFollowLabel>().LastOrDefault(), sender, unwrapped, channel, repeatCheckSender);
             return;
+        }
 
         Contents.AddMessage(formatted, tagsAllowed: null);
-        _entManager.System<CMChatSystem>().UpdateGhostFollowLink(this, Contents.GetControlOfType<GhostFollowLabel>().LastOrDefault());
+        cmChatSystem.AddGhostFollowLink(this, Contents.GetControlOfType<GhostFollowLabel>().LastOrDefault());
     }
 
     public void Focus(ChatSelectChannel? channel = null)

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -1,4 +1,7 @@
-using Content.Client._RMC14.Chat; // Persistence: Chat stacking from RMC14 - pull/7587
+using System.Linq;
+using Content.Client._Funkystation.UserInterface.Controls;
+using Content.Client._RMC14.Chat;
+using Content.Client.UserInterface.ControlExtensions; // Persistence: Chat stacking from RMC14 - pull/7587
 using Content.Client.UserInterface.Systems.Chat.Controls;
 using Content.Shared.Chat;
 using Content.Shared.Input;
@@ -126,6 +129,7 @@ public partial class ChatBox : UIWidget
             return;
 
         Contents.AddMessage(formatted, tagsAllowed: null);
+        _entManager.System<CMChatSystem>().UpdateGhostFollowLink(this, Contents.GetControlOfType<GhostFollowLabel>().LastOrDefault());
     }
 
     public void Focus(ChatSelectChannel? channel = null)

--- a/Content.Client/_Funkystation/UserInterface/Controls/GhostFollowLabel.cs
+++ b/Content.Client/_Funkystation/UserInterface/Controls/GhostFollowLabel.cs
@@ -1,0 +1,8 @@
+using Robust.Client.UserInterface.Controls;
+
+namespace Content.Client._Funkystation.UserInterface.Controls;
+
+public sealed class GhostFollowLabel : Label
+{
+
+}

--- a/Content.Client/_Funkystation/UserInterface/Controls/GhostFollowLabel.cs
+++ b/Content.Client/_Funkystation/UserInterface/Controls/GhostFollowLabel.cs
@@ -2,7 +2,8 @@ using Robust.Client.UserInterface.Controls;
 
 namespace Content.Client._Funkystation.UserInterface.Controls;
 
-public sealed class GhostFollowLabel : Label
-{
-
-}
+/// <summary>
+/// Literally just a <see cref="Label"/>. Exists for the purpose of
+/// making ghost follow command links not break when chat stacked.
+/// </summary>
+public sealed class GhostFollowLabel : Label;

--- a/Content.Client/_Funkystation/UserInterface/RichText/GhostFollowTag.cs
+++ b/Content.Client/_Funkystation/UserInterface/RichText/GhostFollowTag.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics.CodeAnalysis;
+using Content.Client._Funkystation.UserInterface.Controls;
+using Robust.Client.Console;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.RichText;
+using Robust.Shared.Input;
+using Robust.Shared.Utility;
+
+namespace Content.Client._Funkystation.UserInterface.RichText;
+
+public sealed partial class GhostFollowTag : IMarkupTagHandler
+{
+    [Dependency] private IClientConsoleHost _clientConsoleHost = default!;
+
+    public string Name => "ghostfollow";
+
+    /// <inheritdoc/>
+    public bool TryCreateControl(MarkupNode node, [NotNullWhen(true)] out Control? control)
+    {
+        if (!node.Value.TryGetString(out var text)
+            || !node.Attributes.TryGetValue("command", out var commandParameter)
+            || !commandParameter.TryGetString(out var command))
+        {
+            control = null;
+            return false;
+        }
+
+        var label = new GhostFollowLabel();
+        label.Text = text;
+
+        label.MouseFilter = Control.MouseFilterMode.Stop;
+        label.FontColorOverride = Color.LightBlue;
+        label.DefaultCursorShape = Control.CursorShape.Hand;
+
+        label.OnMouseEntered += _ => label.FontColorOverride = Color.Blue;
+        label.OnMouseExited += _ => label.FontColorOverride = Color.LightBlue;
+        label.OnKeyBindDown += args => OnKeybindDown(args, command);
+
+        if (node.Attributes.TryGetValue("title", out var titleArg))
+            label.ToolTip = titleArg.StringValue;
+
+        control = label;
+        return true;
+    }
+
+    private void OnKeybindDown(GUIBoundKeyEventArgs args, string command)
+    {
+        if (args.Function != EngineKeyFunctions.UIClick)
+            return;
+
+        _clientConsoleHost.ExecuteCommand(command);
+    }
+}

--- a/Content.Client/_Funkystation/UserInterface/RichText/GhostFollowTag.cs
+++ b/Content.Client/_Funkystation/UserInterface/RichText/GhostFollowTag.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Client._Funkystation.UserInterface.Controls;
+using JetBrains.Annotations;
 using Robust.Client.Console;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.RichText;
@@ -8,6 +9,11 @@ using Robust.Shared.Utility;
 
 namespace Content.Client._Funkystation.UserInterface.RichText;
 
+/// <summary>
+/// Functionally identical to <see cref="CommandLinkTag"/>, exists to use a unique type
+/// for the purpose of chat stacking ghost follow buttons
+/// </summary>
+[UsedImplicitly]
 public sealed partial class GhostFollowTag : IMarkupTagHandler
 {
     [Dependency] private IClientConsoleHost _clientConsoleHost = default!;

--- a/Content.Client/_Funkystation/UserInterface/RichText/GhostFollowTag.cs
+++ b/Content.Client/_Funkystation/UserInterface/RichText/GhostFollowTag.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using Content.Client._Funkystation.UserInterface.Controls;
 using Robust.Client.Console;
 using Robust.Client.UserInterface;
-using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.RichText;
 using Robust.Shared.Input;
 using Robust.Shared.Utility;

--- a/Content.Client/_RMC14/Chat/CMChatSystem.cs
+++ b/Content.Client/_RMC14/Chat/CMChatSystem.cs
@@ -47,7 +47,6 @@ public sealed partial class CMChatSystem : EntitySystem // Persistence: SharedCM
             var copy = new FormattedMessage(old.FormattedMessage);
             old.Count++;
             copy.AddMarkupPermissive($" [color=red]x{old.Count}[/color]");
-            old.GhostFollowLink?.Orphan();
             contents.SetMessage(old.Index, copy, tagsAllowed: null);
             repeated = true;
             break;
@@ -68,7 +67,29 @@ public sealed partial class CMChatSystem : EntitySystem // Persistence: SharedCM
         return repeated;
     }
 
-    public void UpdateGhostFollowLink(ChatBox chat, GhostFollowLabel? control)
+    public void UpdateGhostFollowLink(ChatBox chat, GhostFollowLabel? control, NetEntity sender, string unwrapped, ChatChannel channel, bool repeatCheckSender)
+    {
+        foreach (var old in chat.RepeatQueue)
+        {
+            if (!old.Message.Equals(unwrapped) ||
+                old.Channel != channel)
+            {
+                continue;
+            }
+
+            if (repeatCheckSender &&
+                !old.SenderEntity.Equals(sender))
+            {
+                continue;
+            }
+
+            old.GhostFollowLink?.Orphan();
+            old.GhostFollowLink = control;
+            break;
+        }
+    }
+
+    public void AddGhostFollowLink(ChatBox chat, GhostFollowLabel? control)
     {
         chat.RepeatQueue.LastOrDefault()?.GhostFollowLink = control;
     }

--- a/Content.Client/_RMC14/Chat/CMChatSystem.cs
+++ b/Content.Client/_RMC14/Chat/CMChatSystem.cs
@@ -67,6 +67,15 @@ public sealed partial class CMChatSystem : EntitySystem // Persistence: SharedCM
         return repeated;
     }
 
+    /// <summary>
+    /// Funky - orphan any ghost follow links attached to repeated messages and attach the new link instead
+    /// </summary>
+    /// <param name="chat"></param>
+    /// <param name="control"></param>
+    /// <param name="sender"></param>
+    /// <param name="unwrapped"></param>
+    /// <param name="channel"></param>
+    /// <param name="repeatCheckSender"></param>
     public void UpdateGhostFollowLink(ChatBox chat, GhostFollowLabel? control, NetEntity sender, string unwrapped, ChatChannel channel, bool repeatCheckSender)
     {
         foreach (var old in chat.RepeatQueue)
@@ -89,6 +98,7 @@ public sealed partial class CMChatSystem : EntitySystem // Persistence: SharedCM
         }
     }
 
+    // funky
     public void AddGhostFollowLink(ChatBox chat, GhostFollowLabel? control)
     {
         chat.RepeatQueue.LastOrDefault()?.GhostFollowLink = control;

--- a/Content.Client/_RMC14/Chat/CMChatSystem.cs
+++ b/Content.Client/_RMC14/Chat/CMChatSystem.cs
@@ -1,4 +1,7 @@
 ﻿// Persistence: Chat stacking from RMC14 - pull/7587
+
+using System.Linq;
+using Content.Client._Funkystation.UserInterface.Controls;
 using Content.Client.UserInterface.Systems.Chat.Widgets;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared.Chat;
@@ -44,6 +47,7 @@ public sealed partial class CMChatSystem : EntitySystem // Persistence: SharedCM
             var copy = new FormattedMessage(old.FormattedMessage);
             old.Count++;
             copy.AddMarkupPermissive($" [color=red]x{old.Count}[/color]");
+            old.GhostFollowLink?.Orphan();
             contents.SetMessage(old.Index, copy, tagsAllowed: null);
             repeated = true;
             break;
@@ -62,5 +66,10 @@ public sealed partial class CMChatSystem : EntitySystem // Persistence: SharedCM
         }
 
         return repeated;
+    }
+
+    public void UpdateGhostFollowLink(ChatBox chat, GhostFollowLabel? control)
+    {
+        chat.RepeatQueue.LastOrDefault()?.GhostFollowLink = control;
     }
 }

--- a/Content.Client/_RMC14/Chat/RepeatedMessage.cs
+++ b/Content.Client/_RMC14/Chat/RepeatedMessage.cs
@@ -20,5 +20,5 @@ public sealed class RepeatedMessage(
     public readonly string Message = message;
     public readonly ChatChannel Channel = channel;
     public int Count = 1;
-    internal GhostFollowLabel? GhostFollowLink;
+    internal GhostFollowLabel? GhostFollowLink; // funky
 }

--- a/Content.Client/_RMC14/Chat/RepeatedMessage.cs
+++ b/Content.Client/_RMC14/Chat/RepeatedMessage.cs
@@ -1,4 +1,6 @@
 ﻿// Persistence: Chat stacking from RMC14 - pull/7587
+
+using Content.Client._Funkystation.UserInterface.Controls;
 using Content.Shared.Chat;
 using Robust.Shared.Utility;
 
@@ -18,4 +20,5 @@ public sealed class RepeatedMessage(
     public readonly string Message = message;
     public readonly ChatChannel Channel = channel;
     public int Count = 1;
+    internal GhostFollowLabel? GhostFollowLink;
 }

--- a/Content.Server/Chat/Managers/ChatManager.cs
+++ b/Content.Server/Chat/Managers/ChatManager.cs
@@ -420,7 +420,7 @@ internal sealed partial class ChatManager : IChatManager
         if (IsValidWarpDestination(source) && ShouldShowFollowButton(recipient))
         {
             var btnText = _localizationManager.GetString("chat-manager-follow-button");
-            return $"[cmdlink=\"{btnText}\" command=\"{GhostFollowEntityCommand.CommandName} {_entityManager.GetNetEntity(source)}\" /] " + wrappedMessage;
+            return $"[ghostfollow=\"{btnText}\" command=\"{GhostFollowEntityCommand.CommandName} {_entityManager.GetNetEntity(source)}\" /] " + wrappedMessage;
         }
 
         return wrappedMessage;

--- a/Content.Server/Chat/Managers/ChatManager.cs
+++ b/Content.Server/Chat/Managers/ChatManager.cs
@@ -420,6 +420,7 @@ internal sealed partial class ChatManager : IChatManager
         if (IsValidWarpDestination(source) && ShouldShowFollowButton(recipient))
         {
             var btnText = _localizationManager.GetString("chat-manager-follow-button");
+            // funky - using a unique ghostfollow command link tag as part of a fix for chat stacking
             return $"[ghostfollow=\"{btnText}\" command=\"{GhostFollowEntityCommand.CommandName} {_entityManager.GetNetEntity(source)}\" /] " + wrappedMessage;
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
<!-- What did you change? -->
the cause of the bug is that when calling SetMessage on an OutputPanel, the method forgets to orphan old controls associated with the message being replaced. SetMessage is used when updating repeated messages and the ghost follow buttons are a control so they break.
this PR is essentially a workaround to let us get the control for the ghost follow button, keep track of it, and orphan it ourselves
### How to enable / disable
<!--
    According to our Conventions, all new content added should be easy for a downstream to disable or opt-out of.
    Content can be opt-out (or opt-in) through the use of CVars, simple YML changes, or simply by not using a feature (if it is made optional in some way, like a mapped entity or an admin-only commmand).

    Explain below how to enable or disable this content. If this is a bugfix, tweak, or a "non-content" change,
    this section can be omitted.
-->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
TEMPORARY FIX FOR [THIS ISSUE](https://discord.com/channels/1276640157511979008/1547839740542189680) reported on the discord - please for the love of god revert it if/when [this fix](https://github.com/space-wizards/RobustToolbox/pull/7080) makes it to Funky
## Technical details
<!-- Summary of code changes for easier review. -->
created a type of markup tag exclusively for ghost follow chat buttons that's literally just a cmdlink tag. the benefit of creating a new tag and type for this is that we can easily get it using GetControlOfType.
when a message is added to the chat, if there's a GhostFollowLabel we associate it with the latest message in the chat stacking RepeatQueue.
if a message is repeated, we orphan the old GhostFollowLabel and associate the new one with the message instead.

as a consequence of how this works, if you were a ghost but then become not-a-ghost then old ghost follow buttons might start disappearing, which doesnt really matter because youre not a ghost anymore anyway.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
send a bunch of messages as a ghost, repeat some of them in a random order, make sure no floating F appears
spin up two more clients, send messages as them, make sure the follow button works correctly and follows the correct person
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->
[Screencast_20260912_221018.webm](https://github.com/user-attachments/assets/562475d9-4bc8-4f0b-9ff8-1b57160a74cc)

Demonstrating the issue mentioned above with disappearing buttons as a non-ghost
<img width="416" height="393" alt="Screenshot_20260912_221204" src="https://github.com/user-attachments/assets/027049ee-4268-4ebe-a93d-415a45ed4eac" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [ ] If I am porting something, I have done my best to respect the appropriate licenses associated with the presented changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- Our repository uses REUSE headers to easily determine who contributed to what, and to also easily segregate files that have different licenses. If you wish to have your PR submitted under a different license, please list it here. Acceptable entries are: MIT, AGPL-3.0-or-later. -->
## License
MIT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Also, include instructions on how to enable/disable the content for the benefit of downstreams.-->
ChatManager.cs prepends a ghostfollow tag instead of a cmdlink tag in PrependFollowButtonIfAppropriate.
## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Ghost follow buttons in the chat window will no longer break and start floating sometimes.